### PR TITLE
Support swype delete key long press

### DIFF
--- a/src/jackpal/androidterm/Term.java
+++ b/src/jackpal/androidterm/Term.java
@@ -2823,9 +2823,15 @@ class EmulatorView extends View implements GestureDetector.OnGestureListener {
 
             @Override
             public boolean deleteSurroundingText(int leftLength, int rightLength) {
-                for (int i = 0; i < leftLength; i++) {
-                    sendKeyEvent(
+                if (leftLength > 0) {
+                    for (int i = 0; i < leftLength; i++) {
+                        sendKeyEvent(
                             new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL));
+                    }
+                } else if ((leftLength == 0) && (rightLength == 0)) {
+                    // Delete key held down / repeating
+                    sendKeyEvent(
+                        new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL));
                 }
                 // TODO: handle forward deletes.
                 return true;


### PR DESCRIPTION
When swype delete key is held down it should continue to generate delete key events.  Long presses are detected by both left and right length being zero.  This change detects the long press condition and sends a delete key event for each.  Delete events speed up as long as delete key is held down.
