### PR TITLE
Add context menus for sending control/fn keys, for the sake of Kindle Fire.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -36,6 +36,8 @@
    <string name="select_text">Select text</string>
    <string name="copy_all">Copy all</string>
    <string name="paste">Paste</string>
+   <string name="send_control_key">Send control key</string>
+   <string name="send_fn_key">Send fn key</string>
 
    <string name="window_title">Window %1$d</string>
 

--- a/src/jackpal/androidterm/EmulatorView.java
+++ b/src/jackpal/androidterm/EmulatorView.java
@@ -168,6 +168,9 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
 
     private boolean mIsSelectingText = false;
 
+    private boolean mIsControlKeySent = false;
+    private boolean mIsFnKeySent = false;
+
 
     private float mDensity;
 
@@ -350,6 +353,7 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
                 } else {
                     mKeyListener.handleKeyCode(result - TermKeyListener.KEYCODE_OFFSET, getKeypadApplicationMode());
                 }
+                clearSpecialKeyStatus();
             }
 
             public boolean beginBatchEdit() {
@@ -868,6 +872,7 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
         }
 
         mKeyListener.keyUp(keyCode);
+        clearSpecialKeyStatus();
         return true;
     }
 
@@ -896,6 +901,17 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
 
     private boolean isSystemKey(int keyCode, KeyEvent event) {
         return event.isSystem();
+    }
+
+    private void clearSpecialKeyStatus() {
+        if (mIsControlKeySent) {
+            mIsControlKeySent = false;
+            mKeyListener.handleControlKey(false);
+        }
+        if (mIsFnKeySent) {
+            mIsFnKeySent = false;
+            mKeyListener.handleFnKey(false);
+        }
     }
 
     private void updateText() {
@@ -1035,6 +1051,16 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
 
     public String getSelectedText() {
         return mEmulator.getSelectedText(mSelX1, mSelY1, mSelX2, mSelY2);
+    }
+
+    public void sendControlKey() {
+        mIsControlKeySent = true;
+        mKeyListener.handleControlKey(true);
+    }
+
+    public void sendFnKey() {
+        mIsFnKeySent = true;
+        mKeyListener.handleFnKey(true);
     }
 }
 

--- a/src/jackpal/androidterm/Term.java
+++ b/src/jackpal/androidterm/Term.java
@@ -79,6 +79,8 @@ public class Term extends Activity implements UpdateCallback {
     private final static int SELECT_TEXT_ID = 0;
     private final static int COPY_ALL_ID = 1;
     private final static int PASTE_ID = 2;
+    private final static int SEND_CONTROL_KEY_ID = 3;
+    private final static int SEND_FN_KEY_ID = 4;
 
     private boolean mAlreadyStarted = false;
     private boolean mStopServiceOnFinish = false;
@@ -435,6 +437,8 @@ public class Term extends Activity implements UpdateCallback {
       menu.add(0, SELECT_TEXT_ID, 0, R.string.select_text);
       menu.add(0, COPY_ALL_ID, 0, R.string.copy_all);
       menu.add(0, PASTE_ID, 0,  R.string.paste);
+      menu.add(0, SEND_CONTROL_KEY_ID, 0, R.string.send_control_key);
+      menu.add(0, SEND_FN_KEY_ID, 0, R.string.send_fn_key);
       if (!canPaste()) {
           menu.getItem(PASTE_ID).setEnabled(false);
       }
@@ -451,6 +455,12 @@ public class Term extends Activity implements UpdateCallback {
             return true;
           case PASTE_ID:
             doPaste();
+            return true;
+          case SEND_CONTROL_KEY_ID:
+            doSendControlKey();
+            return true;
+          case SEND_FN_KEY_ID:
+            doSendFnKey();
             return true;
           default:
             return super.onContextItemSelected(item);
@@ -575,6 +585,14 @@ public class Term extends Activity implements UpdateCallback {
             return;
         }
         getCurrentTermSession().write(paste.toString());
+    }
+
+    private void doSendControlKey() {
+        getCurrentEmulatorView().sendControlKey();
+    }
+
+    private void doSendFnKey() {
+        getCurrentEmulatorView().sendFnKey();
     }
 
     private void doDocumentKeys() {


### PR DESCRIPTION
Hi,

I just bought a Kindle Fire, which doesn't have any physical buttons (apart from the power button). So there was no way to send control/fn keys in the Terminal Emulator, which hurted me a lot. Therefore, I added two context menu items as an alternative approach to send control and fn keys.

Here is an screenshot:

![kindle-fire-send-special-key.png](http://f.cl.ly/items/1h0N1u3a390F1C3j1W0Q/kindle-fire-send-special-key.png)

For example, suppose we want to send "ctrl-x". We first long-tap the screen to bring out the context menu. Then we tap "send control key". Finally, we press the letter "x" on the keyboard.

The "send control key" and "send fn key" here only modify the next key pressed. Let's say if we want to send "ctrl-x ctrl-c", then we need to tap the context menu, press "x", tap the context menu again, and press "c". This behavior is justified since in most cases we only need to modify a single key at a time.

I would be grateful if you could pull my commit. Thanks.
