### PR TITLE
Behave sanely when selected shell is the empty string or doesn't exist

### DIFF
--- a/src/jackpal/androidterm/session/TermSession.java
+++ b/src/jackpal/androidterm/session/TermSession.java
@@ -16,8 +16,10 @@
 
 package jackpal.androidterm.session;
 
+import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -203,8 +205,20 @@ public class TermSession {
     private void createSubprocess(int[] processId) {
         String shell = mSettings.getShell();
         ArrayList<String> argList = parse(shell);
-        String arg0 = argList.get(0);
-        String[] args = argList.toArray(new String[1]);
+
+        String arg0;
+        String[] args;
+        try {
+            arg0 = argList.get(0);
+            if (!(new File(arg0)).exists()) {
+                throw new FileNotFoundException(arg0);
+            }
+            args = argList.toArray(new String[1]);
+        } catch (Exception e) {
+            argList = parse(mSettings.getFailsafeShell());
+            arg0 = argList.get(0);
+            args = argList.toArray(new String[1]);
+        }
 
         String termType = mSettings.getTermType();
         String[] env = new String[1];

--- a/src/jackpal/androidterm/util/TermSettings.java
+++ b/src/jackpal/androidterm/util/TermSettings.java
@@ -40,6 +40,7 @@ public class TermSettings {
     private int mFnKeyId;
     private int mUseCookedIME;
     private String mShell;
+    private String mFailsafeShell;
     private String mInitialCommand;
     private String mTermType;
     private boolean mCloseOnExit;
@@ -125,7 +126,8 @@ public class TermSettings {
         mControlKeyId = Integer.parseInt(res.getString(R.string.pref_controlkey_default));
         mFnKeyId = Integer.parseInt(res.getString(R.string.pref_fnkey_default));
         mUseCookedIME = Integer.parseInt(res.getString(R.string.pref_ime_default));
-        mShell = res.getString(R.string.pref_shell_default);
+        mFailsafeShell = res.getString(R.string.pref_shell_default);
+        mShell = mFailsafeShell;
         mInitialCommand = res.getString(R.string.pref_initialcommand_default);
         mTermType = res.getString(R.string.pref_termtype_default);
         mCloseOnExit = res.getBoolean(R.bool.pref_close_window_on_process_exit_default);
@@ -239,6 +241,10 @@ public class TermSettings {
 
     public String getShell() {
         return mShell;
+    }
+
+    public String getFailsafeShell() {
+        return mFailsafeShell;
     }
 
     public String getInitialCommand() {


### PR DESCRIPTION
Yeah, I finally gave in and signed up for github ;)  This solves an occasionally reported regression where setting the default shell to the empty string or an invalid value causes a crash or an immediate exit (probably introduced by one of my defaults patches).
