### PR TITLE
IME enter key return char '/r' instead of '/n'

### DIFF
--- a/src/jackpal/androidterm/EmulatorView.java
+++ b/src/jackpal/androidterm/EmulatorView.java
@@ -502,7 +502,7 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
                 }
                 if (actionCode == EditorInfo.IME_ACTION_UNSPECIFIED) {
                     // The "return" key has been pressed on the IME.
-                    sendText("\n");
+                    sendText("\r");
                 }
                 return true;
             }


### PR DESCRIPTION
IME enter key return char '/r' instead of '/n', fixes issue #102 and #21.
