### PR TITLE
Hook ctrl keys on hardware keyboards.

### DIFF
--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
@@ -1043,11 +1043,35 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
             }
         }
 
+        if (handleHardwareControlKey(keyCode, event.getAction() == KeyEvent.ACTION_DOWN)) {
+                return true;
+        }
+
+        if (mKeyListener.isCtrlActive()) {
+            if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                return onKeyDown(keyCode, event);
+            } else {
+                return onKeyUp(keyCode, event);
+            }
+        }
+
         return super.onKeyPreIme(keyCode, event);
     };
 
     private boolean handleControlKey(int keyCode, boolean down) {
         if (keyCode == mControlKeyCode) {
+            if (LOG_KEY_EVENTS) {
+                Log.w(TAG, "handleControlKey " + keyCode);
+            }
+            mKeyListener.handleControlKey(down);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean handleHardwareControlKey(int keyCode, boolean down) {
+        if (keyCode == TermKeyListener.KEYCODE_CTRL_LEFT ||
+            keyCode == TermKeyListener.KEYCODE_CTRL_RIGHT) {
             if (LOG_KEY_EVENTS) {
                 Log.w(TAG, "handleControlKey " + keyCode);
             }

--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/TermKeyListener.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/TermKeyListener.java
@@ -954,4 +954,8 @@ class TermKeyListener {
     public boolean isAltActive() {
         return mAltKey.isActive();
     }
+
+    public boolean isCtrlActive() {
+        return mControlKey.isActive();
+    }
 }


### PR DESCRIPTION
Some IMEs (for example Google Japanese Input) consume key events around Ctrl-keys.
So we should hook key events before they are got by IME.

This patch is harmless also in case without IME.
