### PR TITLE
Remove "Dead Code" warnings.

### DIFF
--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorDebug.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorDebug.java
@@ -29,19 +29,19 @@ class EmulatorDebug {
     /**
      * Set to true to log IME calls.
      */
-    public static final boolean LOG_IME = DEBUG && false;
+    public static final boolean LOG_IME = DEBUG & false;
 
     /**
      * Set to true to log each character received from the remote process to the
      * android log, which makes it easier to debug some kinds of problems with
      * emulating escape sequences and control codes.
      */
-    public static final boolean LOG_CHARACTERS_FLAG = DEBUG && false;
+    public static final boolean LOG_CHARACTERS_FLAG = DEBUG & false;
 
     /**
      * Set to true to log unknown escape sequences.
      */
-    public static final boolean LOG_UNKNOWN_ESCAPE_SEQUENCES = DEBUG && false;
+    public static final boolean LOG_UNKNOWN_ESCAPE_SEQUENCES = DEBUG & false;
 
     /**
      * The tag we use when logging, so that our messages can be distinguished


### PR DESCRIPTION
This is not a serious bug fix.  Just suppress warnings.
