### PR TITLE
Add android:minSdkVersion="3".

### DIFF
--- a/libraries/emulatorview/AndroidManifest.xml
+++ b/libraries/emulatorview/AndroidManifest.xml
@@ -3,4 +3,5 @@
       package="jackpal.androidterm.emulatorview"
       android:versionCode="43"
       android:versionName="1.0.42">
+    <uses-sdk android:minSdkVersion="3"/>
 </manifest>


### PR DESCRIPTION
We will get some errors on recent ADT without this patch.
