### PR TITLE
Fixed hardware control 'stickyness' when switching views

### DIFF
--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
@@ -340,6 +340,10 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
         if (mCursorBlink != 0) {
             mHandler.postDelayed(mBlinkCursor, CURSOR_BLINK_PERIOD);
         }
+
+        // Ensure we don't have any left-over modifier state when switching
+        // views
+        mKeyListener.handleHardwareControlKey(false);
     }
 
     /**


### PR DESCRIPTION
To reproduce bug:
1. Hold down ctrl on a physical keyboard.
2. Create a new window using the (+) icon.
3. Type exit to close the new window.
4. Attempt to type into the original, control key
   is still flagged as being pressed.
