### PR TITLE
Add new ClipboardManager support.

### DIFF
--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
@@ -16,6 +16,9 @@
 
 package jackpal.androidterm.emulatorview;
 
+import jackpal.androidterm.emulatorview.compat.ClipboardManagerCompat;
+import jackpal.androidterm.emulatorview.compat.ClipboardManagerCompatFactory;
+
 import java.io.IOException;
 
 import android.content.Context;
@@ -24,7 +27,6 @@ import android.graphics.Paint;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.text.ClipboardManager;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
@@ -915,7 +917,6 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
         }
     }
 
-    @SuppressWarnings("deprecation")
     private boolean onTouchEventWhileSelectingText(MotionEvent ev) {
         int action = ev.getAction();
         int cx = (int)(ev.getX() / mCharacterWidth);
@@ -942,9 +943,8 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
             mSelX2 = maxx;
             mSelY2 = maxy;
             if (action == MotionEvent.ACTION_UP) {
-                ClipboardManager clip = (ClipboardManager)
-                     getContext().getApplicationContext()
-                         .getSystemService(Context.CLIPBOARD_SERVICE);
+                ClipboardManagerCompat clip = ClipboardManagerCompatFactory
+                        .getManager(getContext().getApplicationContext());
                 clip.setText(getSelectedText().trim());
                 toggleSelectingText();
             }

--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompat.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompat.java
@@ -1,0 +1,9 @@
+package jackpal.androidterm.emulatorview.compat;
+
+public interface ClipboardManagerCompat {
+	CharSequence getText();
+
+	boolean hasText();
+
+    void setText(CharSequence text);
+}

--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatFactory.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatFactory.java
@@ -1,0 +1,18 @@
+package jackpal.androidterm.emulatorview.compat;
+
+import android.content.Context;
+
+public class ClipboardManagerCompatFactory {
+
+    private ClipboardManagerCompatFactory() {
+        /* singleton */
+    }
+
+    public static ClipboardManagerCompat getManager(Context context) {
+        if (AndroidCompat.SDK < 11) {
+            return new ClipboardManagerCompatV1(context);
+        } else {
+            return new ClipboardManagerCompatV11(context);
+        }
+    }
+}

--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV1.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV1.java
@@ -1,0 +1,29 @@
+package jackpal.androidterm.emulatorview.compat;
+
+import android.content.Context;
+import android.text.ClipboardManager;
+
+@SuppressWarnings("deprecation")
+public class ClipboardManagerCompatV1 implements ClipboardManagerCompat {
+    private final ClipboardManager clip;
+
+    public ClipboardManagerCompatV1(Context context) {
+        clip = (ClipboardManager) context.getApplicationContext()
+                .getSystemService(Context.CLIPBOARD_SERVICE);
+    }
+
+    @Override
+    public CharSequence getText() {
+        return clip.getText();
+    }
+
+    @Override
+    public boolean hasText() {
+        return clip.hasText();
+    }
+
+    @Override
+    public void setText(CharSequence text) {
+        clip.setText(text);
+    }
+}

--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV11.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV11.java
@@ -1,0 +1,35 @@
+package jackpal.androidterm.emulatorview.compat;
+
+import android.annotation.SuppressLint;
+import android.content.ClipData;
+import android.content.ClipDescription;
+import android.content.Context;
+import android.content.ClipboardManager;
+
+@SuppressLint("NewApi")
+public class ClipboardManagerCompatV11 implements ClipboardManagerCompat {
+    private final ClipboardManager clip;
+
+    public ClipboardManagerCompatV11(Context context) {
+        clip = (ClipboardManager) context.getApplicationContext()
+                .getSystemService(Context.CLIPBOARD_SERVICE);
+    }
+
+    @Override
+    public CharSequence getText() {
+        ClipData.Item item = clip.getPrimaryClip().getItemAt(0);
+        return item.getText();
+    }
+
+    @Override
+    public boolean hasText() {
+        return (clip.hasPrimaryClip() && clip.getPrimaryClipDescription()
+                .hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN));
+    }
+
+    @Override
+    public void setText(CharSequence text) {
+        ClipData clipData = ClipData.newPlainText("simple text", text);
+        clip.setPrimaryClip(clipData);
+    }
+}

--- a/src/jackpal/androidterm/Term.java
+++ b/src/jackpal/androidterm/Term.java
@@ -16,6 +16,9 @@
 
 package jackpal.androidterm;
 
+import jackpal.androidterm.emulatorview.compat.ClipboardManagerCompat;
+import jackpal.androidterm.emulatorview.compat.ClipboardManagerCompatFactory;
+
 import java.io.UnsupportedEncodingException;
 import java.text.Collator;
 import java.util.Arrays;
@@ -40,7 +43,6 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
-import android.text.ClipboardManager;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -892,7 +894,8 @@ public class Term extends Activity implements UpdateCallback {
     }
 
     private boolean canPaste() {
-        ClipboardManager clip = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipboardManagerCompat clip = ClipboardManagerCompatFactory
+                .getManager(getApplicationContext());
         if (clip.hasText()) {
             return true;
         }
@@ -941,14 +944,14 @@ public class Term extends Activity implements UpdateCallback {
     }
 
     private void doCopyAll() {
-        ClipboardManager clip = (ClipboardManager)
-             getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipboardManagerCompat clip = ClipboardManagerCompatFactory
+                .getManager(getApplicationContext());
         clip.setText(getCurrentTermSession().getTranscriptText().trim());
     }
 
     private void doPaste() {
-        ClipboardManager clip = (ClipboardManager)
-         getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipboardManagerCompat clip = ClipboardManagerCompatFactory
+                .getManager(getApplicationContext());
         CharSequence paste = clip.getText();
         byte[] utf8;
         try {


### PR DESCRIPTION
text.ClipboardManager is obsolete.
Recent versions of text.ClipboardManager seems to be incompatible with test.ClipboardManager.
So it's better to use new ClipboardManager on recent Androids.

My patch was tested on 4.2.2 and 2.4.3 and they works well.
