### PR TITLE
clip mouse to limits of 8-bit data

### DIFF
--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
@@ -890,16 +890,24 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
     private void sendMouseEventCode(MotionEvent e, int button_code) {
         int x = (int)(e.getX() / mCharacterWidth) + 1;
         int y = (int)((e.getY()-mTopOfScreenMargin) / mCharacterHeight) + 1;
-        x = Math.max(1, Math.min(mColumns, x));
-        y = Math.max(1, Math.min(mRows, y));
-        //Log.d(TAG, "mouse button "+x+","+y+","+button_code);
-
-        byte[] data = {
-            '\033', '[', 'M',
-            (byte)(32 + button_code),
-            (byte)(32 + x),
-            (byte)(32 + y) };
-        mTermSession.write(data, 0, data.length);
+        // Clip to screen, and clip to the limits of 8-bit data.
+        boolean out_of_bounds =
+            x < 1 || y < 1 ||
+            x > mColumns || y > mRows ||
+            x > 255-32 || y > 255-32;
+        //Log.d(TAG, "mouse button "+x+","+y+","+button_code+",oob="+out_of_bounds);
+        if(button_code < 0 || button_code > 255-32) {
+            Log.e(TAG, "mouse button_code out of range: "+button_code);
+            return;
+        }
+        if(!out_of_bounds) {
+            byte[] data = {
+                '\033', '[', 'M',
+                (byte)(32 + button_code),
+                (byte)(32 + x),
+                (byte)(32 + y) };
+            mTermSession.write(data, 0, data.length);
+        }
     }
 
     // Begin GestureDetector.OnGestureListener methods


### PR DESCRIPTION
When sending mouse events as terminal codes, avoid overflow due to the limitations of 8-bit data.  I chose to just not send events when out-of-bounds (even for scroll), which is what konsole does.  xterm chooses to send 0 for the coordinate in this case.  I don't know whether there is a reason that konsole doesn't do it that way...  Also, konsole maxes out at column 222 rather than 223 (corresponding to sending 0xfe).  I don't know why, perhaps that's a bug.  Xterm and gnome-terminal will send 0xff for column 223, and I do it this way.

There are competing proposals for how to handle rows/columns greater than 223.  Konsole doesn't implement either of these, so I assume they are not currently in demand.  If someone needs columns >223 I can implement this.
