### PR TITLE
Added support for DECCKM (Cursor Keys Mode).

### DIFF
--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/EmulatorView.java
@@ -469,7 +469,7 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
                 if (result < TermKeyListener.KEYCODE_OFFSET) {
                     mTermSession.write(result);
                 } else {
-                    mKeyListener.handleKeyCode(result - TermKeyListener.KEYCODE_OFFSET, getKeypadApplicationMode());
+                    mKeyListener.handleKeyCode(result - TermKeyListener.KEYCODE_OFFSET, getKeypadApplicationMode(), getCursorApplicationMode());
                 }
                 clearSpecialKeyStatus();
             }
@@ -728,6 +728,13 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
      */
     public boolean getKeypadApplicationMode() {
         return mEmulator.getKeypadApplicationMode();
+    }
+
+    /**
+     * Get the terminal emulator's cursor application mode.
+     */
+    public boolean getCursorApplicationMode() {
+        return mEmulator.getCursorApplicationMode();
     }
 
     /**
@@ -1092,7 +1099,7 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
         try {
             int oldCombiningAccent = mKeyListener.getCombiningAccent();
             int oldCursorMode = mKeyListener.getCursorMode();
-            mKeyListener.keyDown(keyCode, event, getKeypadApplicationMode(),
+            mKeyListener.keyDown(keyCode, event, getKeypadApplicationMode(), getCursorApplicationMode(),
                     TermKeyListener.isEventFromToggleDevice(event));
             if (mKeyListener.getCombiningAccent() != oldCombiningAccent
                     || mKeyListener.getCursorMode() != oldCursorMode) {

--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/TerminalEmulator.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/TerminalEmulator.java
@@ -311,6 +311,8 @@ class TerminalEmulator {
     private int mEffect;
 
     private boolean mbKeypadApplicationMode;
+    private boolean mbCursorApplicationMode;
+
 
     /** false == G0, true == G1 */
     private boolean mAlternateCharSet;
@@ -584,6 +586,10 @@ class TerminalEmulator {
      */
     public final int getMouseTrackingMode() {
         return mMouseTrackingMode;
+    }
+
+    public final boolean getCursorApplicationMode() {
+        return mbCursorApplicationMode;
     }
 
     private void setDefaultTabStops() {
@@ -861,10 +867,25 @@ class TerminalEmulator {
         int mask = getDecFlagsMask(arg);
         int oldFlags = mDecFlags;
         switch (b) {
-        case 'h': // Esc [ ? Pn h - DECSET
-            mDecFlags |= mask;
-            if (arg >= 1000 && arg <= 1003) {
-                mMouseTrackingMode = arg;
+
+        case '1':
+            if(getArg0(0) == 1){
+                // Esc [ ? Pn 11 (DECCKM set)
+                mbCursorApplicationMode = false;
+            } else {
+                parseArg(b);
+            }
+            break;
+        case 'h':
+            if(getArg0(0) == 1){
+                // Esc [ ? Pn 1h (DECCKM reset)
+                mbCursorApplicationMode = true;
+            } else {
+                // Esc [ ? Pn h - DECSET
+                mDecFlags |= mask;
+                if (arg >= 1000 && arg <= 1003) {
+                    mMouseTrackingMode = arg;
+                }
             }
             break;
 
@@ -1844,6 +1865,7 @@ class TerminalEmulator {
         mForeColor = mDefaultForeColor;
         mBackColor = mDefaultBackColor;
         mbKeypadApplicationMode = false;
+        mbCursorApplicationMode = false;
         mAlternateCharSet = false;
         mCharSet[0] = CHAR_SET_ASCII;
         mCharSet[1] = CHAR_SET_SPECIAL_GRAPHICS;


### PR DESCRIPTION
This fixes arrow keys when using Mosh - which doesn't work properly with just keypad application mode. This should also fix issue #264.
