### PR TITLE
Enable hardware acceleration

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -25,7 +25,8 @@
                 android:permissionGroup="android.permission-group.SYSTEM_TOOLS"
                 android:protectionLevel="dangerous" />
     <application android:icon="@drawable/ic_launcher"
-                android:label="@string/application_terminal">
+                android:label="@string/application_terminal"
+                android:hardwareAccelerated="true">
         <activity android:name="Term"
                 android:theme="@style/Theme"
                 android:launchMode="singleTask"


### PR DESCRIPTION
The settings are pretty sluggish on not so powerful devices.
If you think that it's not required to enable it for the entire application, I'd suggest to enable it at least for "TermPreferences"
