### PR TITLE
Exec procedure improvements

### DIFF
--- a/jni/termExec.cpp
+++ b/jni/termExec.cpp
@@ -129,6 +129,8 @@ static int create_subprocess(const char *cmd,
         pts = open(devname, O_RDWR);
         if(pts < 0) exit(-1);
 
+        ioctl(pts, TIOCSCTTY, 0);
+
         dup2(pts, 0);
         dup2(pts, 1);
         dup2(pts, 2);


### PR DESCRIPTION
The java process maintains many open file descriptors that are inherited by the shell process (and later on by any command spawned by the shell). This code closes all of them by iterating over the /proc/self/fd directory. Also includes an ioctl call to make the pseudoterminal a controlling one for the shell process group.
