### PR TITLE
Linkification bugfixes

### DIFF
--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/TranscriptScreen.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/TranscriptScreen.java
@@ -433,7 +433,7 @@ class TranscriptScreen implements Screen {
      * @param row The row index to be queried
      * @return The line of text at this row index
      */
-    public char[] getScriptLine(int row)
+    char[] getScriptLine(int row)
     {
         try
         {
@@ -454,8 +454,20 @@ class TranscriptScreen implements Screen {
      * @param row The row to check for line-wrap status
      * @return The line wrap status of the row provided
      */
-    public boolean getScriptLineWrap(int row)
+    boolean getScriptLineWrap(int row)
     {
         return mData.getLineWrap(row);
+    }
+
+    /**
+     * Get whether the line at this index is "basic" (contains only BMP
+     * characters of width 1).
+     */
+    boolean isBasicLine(int row) {
+        if (mData != null) {
+            return mData.isBasicLine(row);
+        } else {
+            return true;
+        }
     }
 }

--- a/libraries/emulatorview/src/jackpal/androidterm/emulatorview/UnicodeTranscript.java
+++ b/libraries/emulatorview/src/jackpal/androidterm/emulatorview/UnicodeTranscript.java
@@ -650,6 +650,14 @@ class UnicodeTranscript {
         return getLineColor(row, 0, mColumns);
     }
 
+    boolean isBasicLine(int row) {
+        if (row < -mActiveTranscriptRows || row > mScreenRows-1) {
+            throw new IllegalArgumentException();
+        }
+
+        return (mLines[externalToInternalRow(row)] instanceof char[]);
+    }
+
     public boolean getChar(int row, int column) {
         return getChar(row, column, 0);
     }


### PR DESCRIPTION
These patches fix bugs with the placement of links:
- The last character of a link's text wasn't being made clickable
- The clickable portion of the line doesn't line up with the link text if the link is on a line containing non-BMP characters, combining characters or East Asian wide characters

Lightly tested on various emulators and on a phone and tablet running 4.4.
