### PR TITLE
Prevent abuse of intents

### DIFF
--- a/term/src/main/AndroidManifest.xml
+++ b/term/src/main/AndroidManifest.xml
@@ -71,14 +71,14 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity-alias>
-        <activity-alias android:name="RunScript"
-                android:targetActivity="RemoteInterface"
+        <activity android:name="RunScript"
+                android:excludeFromRecents="true"
                 android:permission="jackpal.androidterm.permission.RUN_SCRIPT">
             <intent-filter>
                 <action android:name="jackpal.androidterm.RUN_SCRIPT" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-        </activity-alias>
+        </activity>
         <activity android:name="TermPreferences"
                 android:label="@string/preferences"/>
         <activity android:name="WindowList"

--- a/term/src/main/java/jackpal/androidterm/RemoteInterface.java
+++ b/term/src/main/java/jackpal/androidterm/RemoteInterface.java
@@ -41,6 +41,8 @@ public class RemoteInterface extends Activity {
 
     protected static final String PRIVEXTRA_TARGET_WINDOW = "jackpal.androidterm.private.target_window";
 
+    protected static final String PRIVACT_ACTIVITY_ALIAS = "jackpal.androidterm.TermInternal";
+
     private TermSettings mSettings;
 
     private TermService mTermService;

--- a/term/src/main/java/jackpal/androidterm/RunScript.java
+++ b/term/src/main/java/jackpal/androidterm/RunScript.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2012 Steven Luo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jackpal.androidterm;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Log;
+
+/*
+ * New procedure for launching a command in ATE.
+ * Build the path and arguments into a Uri and set that into Intent.data.
+ * intent.data(new Uri.Builder().setScheme("file").setPath(path).setFragment(arguments))
+ *
+ * The old procedure of using Intent.Extra is still available but is discouraged.
+ */
+public final class RunScript extends RemoteInterface {
+    private static final String ACTION_RUN_SCRIPT = "jackpal.androidterm.RUN_SCRIPT";
+
+    private static final String EXTRA_WINDOW_HANDLE = "jackpal.androidterm.window_handle";
+    private static final String EXTRA_INITIAL_COMMAND = "jackpal.androidterm.iInitialCommand";
+
+    @Override
+    protected void handleIntent() {
+        TermService service = getTermService();
+        if (service == null) {
+            finish();
+            return;
+        }
+
+        Intent myIntent = getIntent();
+        String action = myIntent.getAction();
+        if (action.equals(ACTION_RUN_SCRIPT)) {
+            /* Someone with the appropriate permissions has asked us to
+               run a script */
+            String handle = myIntent.getStringExtra(EXTRA_WINDOW_HANDLE);
+            String command=null;
+            /*
+             * First look in Intent.data for the path; if not there, revert to
+             * the EXTRA_INITIAL_COMMAND location.
+             */
+            Uri uri=myIntent.getData();
+            if(uri!=null) // scheme[path][arguments]
+            {
+              String s=uri.getScheme();
+              if(s!=null && s.toLowerCase().equals("file"))
+              {
+                command=uri.getPath();
+                // Allow for the command to be contained within the arguments string.
+                if(command==null) command="";
+                if(!command.equals("")) command=quoteForBash(command);
+                // Append any arguments.
+                if(null!=(s=uri.getFragment())) command+=" "+s;
+              }
+            }
+            // If Intent.data not used then fall back to old method.
+            if(command==null) command=myIntent.getStringExtra(EXTRA_INITIAL_COMMAND);
+            if (handle != null) {
+                // Target the request at an existing window if open
+                handle = appendToWindow(handle, command);
+            } else {
+                // Open a new window
+                handle = openNewWindow(command);
+            }
+            Intent result = new Intent();
+            result.putExtra(EXTRA_WINDOW_HANDLE, handle);
+            setResult(RESULT_OK, result);
+
+            finish();
+        } else {
+            super.handleIntent();
+        }
+    }
+}

--- a/term/src/main/java/jackpal/androidterm/Term.java
+++ b/term/src/main/java/jackpal/androidterm/Term.java
@@ -108,6 +108,7 @@ public class Term extends Activity implements UpdateCallback {
     public static final int REQUEST_CHOOSE_WINDOW = 1;
     public static final String EXTRA_WINDOW_ID = "jackpal.androidterm.window_id";
     private int onResumeSelectWindow = -1;
+    private ComponentName mPrivateAlias;
 
     private PowerManager.WakeLock mWakeLock;
     private WifiManager.WifiLock mWifiLock;
@@ -319,6 +320,7 @@ public class Term extends Activity implements UpdateCallback {
         Log.e(TermDebug.LOG_TAG, "onCreate");
         mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         mSettings = new TermSettings(getResources(), mPrefs);
+        mPrivateAlias = new ComponentName(this, RemoteInterface.PRIVACT_ACTIVITY_ALIAS);
 
         Intent broadcast = new Intent(ACTION_PATH_BROADCAST);
         if (AndroidCompat.SDK >= 12) {
@@ -421,8 +423,9 @@ public class Term extends Activity implements UpdateCallback {
             Intent intent = getIntent();
             int flags = intent.getFlags();
             String action = intent.getAction();
+            ComponentName component = intent.getComponent();
             if ((flags & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0 &&
-                    action != null) {
+                    action != null && mPrivateAlias.equals(component)) {
                 if (action.equals(RemoteInterface.PRIVACT_OPEN_NEW_WINDOW)) {
                     mViewFlipper.setDisplayedChild(mTermSessions.size()-1);
                 } else if (action.equals(RemoteInterface.PRIVACT_SWITCH_WINDOW)) {
@@ -815,7 +818,7 @@ public class Term extends Activity implements UpdateCallback {
         }
 
         String action = intent.getAction();
-        if (action == null) {
+        if (action == null || !mPrivateAlias.equals(intent.getComponent())) {
             return;
         }
 


### PR DESCRIPTION
The patches in this series address the problem pointed out by @daoyuan14 in #374: the use of intent filters on activity aliases isn't sufficient to prevent outside users from triggering an intent if those intents are implemented by public, unprotected components.  Specifically:

* Patch 1 (5112961) closes the security hole reported in #374 by moving RUN_SCRIPT handling into its own activity, ensuring that outside users cannot bypass the permssion check by explicitly targeting the main RemoteInterface.
* Patch 2 (1c57509) protects a couple of internal-use-only intents in the Term activity from outside use by ignoring invocations that don't target the non-exported TermInternal alias.  The impact of any potential mischief here is relatively low (I was unable to do more than change the current window, though I wouldn't put a crash completely beyond the realm of possibility), but this patch should be fairly low-risk (the only legitimate user of these intents is the remote interface, and that should be completely broken if this patch were to break things).

Lightly tested on a handful of emulators and a phone running 4.4.