### PR TITLE
Shortcut improvements

### DIFF
--- a/term/src/main/java/jackpal/androidterm/RunShortcut.java
+++ b/term/src/main/java/jackpal/androidterm/RunShortcut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Steven Luo
+ * Copyright (C) 2015 Steven Luo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import jackpal.androidterm.util.ShortcutEncryption;
 import java.security.GeneralSecurityException;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.util.Log;
 
 public final class RunShortcut extends RemoteInterface {
@@ -52,6 +51,7 @@ public final class RunShortcut extends RemoteInterface {
             ShortcutEncryption.Keys keys = ShortcutEncryption.getKeys(this);
             if (keys == null) {
                 // No keys -- no valid shortcuts can exist
+                Log.e(TermDebug.LOG_TAG, "No shortcut encryption keys found!");
                 finish();
                 return;
             }

--- a/term/src/main/java/jackpal/androidterm/compat/Base64.java
+++ b/term/src/main/java/jackpal/androidterm/compat/Base64.java
@@ -21,6 +21,8 @@ package jackpal.androidterm.compat;
  *
  * https://android.googlesource.com/platform/frameworks/base/+/android-5.0.0_r6/core/java/android/util/Base64.java
  *
+ * to provide a Base64 implementation on Android API < 8 (where Base64 is not
+ * a part of the public API).
  */
 
 import java.io.UnsupportedEncodingException;

--- a/term/src/main/java/jackpal/androidterm/compat/PRNGFixes.java
+++ b/term/src/main/java/jackpal/androidterm/compat/PRNGFixes.java
@@ -72,8 +72,8 @@ public final class PRNGFixes {
      * @throws SecurityException if the fix is needed but could not be applied.
      */
     private static void applyOpenSSLFix() throws SecurityException {
-        if ((Build.VERSION.SDK_INT < VERSION_CODE_JELLY_BEAN)
-                || (Build.VERSION.SDK_INT > VERSION_CODE_JELLY_BEAN_MR2)) {
+        if ((AndroidCompat.SDK < VERSION_CODE_JELLY_BEAN)
+                || (AndroidCompat.SDK > VERSION_CODE_JELLY_BEAN_MR2)) {
             // No need to apply the fix
             return;
         }
@@ -108,7 +108,7 @@ public final class PRNGFixes {
      */
     private static void installLinuxPRNGSecureRandom()
             throws SecurityException {
-        if (Build.VERSION.SDK_INT > VERSION_CODE_JELLY_BEAN_MR2) {
+        if (AndroidCompat.SDK > VERSION_CODE_JELLY_BEAN_MR2) {
             // No need to apply the fix
             return;
         }

--- a/term/src/main/java/jackpal/androidterm/compat/PRNGFixes.java
+++ b/term/src/main/java/jackpal/androidterm/compat/PRNGFixes.java
@@ -1,0 +1,345 @@
+/*
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will Google be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, as long as the origin is not misrepresented.
+ */
+
+package jackpal.androidterm.compat;
+
+/**
+ * Copied from
+ *
+ * http://android-developers.blogspot.com/2013/08/some-securerandom-thoughts.html
+ *
+ * to work around entropy-quality problems with Android's SecureRandom
+ * implementations before 4.4.
+ */
+
+import android.os.Build;
+import android.os.Process;
+import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.SecureRandomSpi;
+import java.security.Security;
+
+/**
+ * Fixes for the output of the default PRNG having low entropy.
+ *
+ * The fixes need to be applied via {@link #apply()} before any use of Java
+ * Cryptography Architecture primitives. A good place to invoke them is in the
+ * application's {@code onCreate}.
+ */
+public final class PRNGFixes {
+
+    private static final int VERSION_CODE_JELLY_BEAN = 16;
+    private static final int VERSION_CODE_JELLY_BEAN_MR2 = 18;
+    private static final byte[] BUILD_FINGERPRINT_AND_DEVICE_SERIAL =
+        getBuildFingerprintAndDeviceSerial();
+
+    /** Hidden constructor to prevent instantiation. */
+    private PRNGFixes() {}
+
+    /**
+     * Applies all fixes.
+     *
+     * @throws SecurityException if a fix is needed but could not be applied.
+     */
+    public static void apply() {
+        applyOpenSSLFix();
+        installLinuxPRNGSecureRandom();
+    }
+
+    /**
+     * Applies the fix for OpenSSL PRNG having low entropy. Does nothing if the
+     * fix is not needed.
+     *
+     * @throws SecurityException if the fix is needed but could not be applied.
+     */
+    private static void applyOpenSSLFix() throws SecurityException {
+        if ((Build.VERSION.SDK_INT < VERSION_CODE_JELLY_BEAN)
+                || (Build.VERSION.SDK_INT > VERSION_CODE_JELLY_BEAN_MR2)) {
+            // No need to apply the fix
+            return;
+        }
+
+        try {
+            // Mix in the device- and invocation-specific seed.
+            Class.forName("org.apache.harmony.xnet.provider.jsse.NativeCrypto")
+                    .getMethod("RAND_seed", byte[].class)
+                    .invoke(null, generateSeed());
+
+            // Mix output of Linux PRNG into OpenSSL's PRNG
+            int bytesRead = (Integer) Class.forName(
+                    "org.apache.harmony.xnet.provider.jsse.NativeCrypto")
+                    .getMethod("RAND_load_file", String.class, long.class)
+                    .invoke(null, "/dev/urandom", 1024);
+            if (bytesRead != 1024) {
+                throw new IOException(
+                        "Unexpected number of bytes read from Linux PRNG: "
+                                + bytesRead);
+            }
+        } catch (Exception e) {
+            throw new SecurityException("Failed to seed OpenSSL PRNG", e);
+        }
+    }
+
+    /**
+     * Installs a Linux PRNG-backed {@code SecureRandom} implementation as the
+     * default. Does nothing if the implementation is already the default or if
+     * there is not need to install the implementation.
+     *
+     * @throws SecurityException if the fix is needed but could not be applied.
+     */
+    private static void installLinuxPRNGSecureRandom()
+            throws SecurityException {
+        if (Build.VERSION.SDK_INT > VERSION_CODE_JELLY_BEAN_MR2) {
+            // No need to apply the fix
+            return;
+        }
+
+        // Install a Linux PRNG-based SecureRandom implementation as the
+        // default, if not yet installed.
+        Provider[] secureRandomProviders =
+                Security.getProviders("SecureRandom.SHA1PRNG");
+        if ((secureRandomProviders == null)
+                || (secureRandomProviders.length < 1)
+                || (!LinuxPRNGSecureRandomProvider.class.equals(
+                        secureRandomProviders[0].getClass()))) {
+            Security.insertProviderAt(new LinuxPRNGSecureRandomProvider(), 1);
+        }
+
+        // Assert that new SecureRandom() and
+        // SecureRandom.getInstance("SHA1PRNG") return a SecureRandom backed
+        // by the Linux PRNG-based SecureRandom implementation.
+        SecureRandom rng1 = new SecureRandom();
+        if (!LinuxPRNGSecureRandomProvider.class.equals(
+                rng1.getProvider().getClass())) {
+            throw new SecurityException(
+                    "new SecureRandom() backed by wrong Provider: "
+                            + rng1.getProvider().getClass());
+        }
+
+        SecureRandom rng2;
+        try {
+            rng2 = SecureRandom.getInstance("SHA1PRNG");
+        } catch (NoSuchAlgorithmException e) {
+            throw new SecurityException("SHA1PRNG not available", e);
+        }
+        if (!LinuxPRNGSecureRandomProvider.class.equals(
+                rng2.getProvider().getClass())) {
+            throw new SecurityException(
+                    "SecureRandom.getInstance(\"SHA1PRNG\") backed by wrong"
+                    + " Provider: " + rng2.getProvider().getClass());
+        }
+    }
+
+    /**
+     * {@code Provider} of {@code SecureRandom} engines which pass through
+     * all requests to the Linux PRNG.
+     */
+    private static class LinuxPRNGSecureRandomProvider extends Provider {
+
+        public LinuxPRNGSecureRandomProvider() {
+            super("LinuxPRNG",
+                    1.0,
+                    "A Linux-specific random number provider that uses"
+                        + " /dev/urandom");
+            // Although /dev/urandom is not a SHA-1 PRNG, some apps
+            // explicitly request a SHA1PRNG SecureRandom and we thus need to
+            // prevent them from getting the default implementation whose output
+            // may have low entropy.
+            put("SecureRandom.SHA1PRNG", LinuxPRNGSecureRandom.class.getName());
+            put("SecureRandom.SHA1PRNG ImplementedIn", "Software");
+        }
+    }
+
+    /**
+     * {@link SecureRandomSpi} which passes all requests to the Linux PRNG
+     * ({@code /dev/urandom}).
+     */
+    public static class LinuxPRNGSecureRandom extends SecureRandomSpi {
+
+        /*
+         * IMPLEMENTATION NOTE: Requests to generate bytes and to mix in a seed
+         * are passed through to the Linux PRNG (/dev/urandom). Instances of
+         * this class seed themselves by mixing in the current time, PID, UID,
+         * build fingerprint, and hardware serial number (where available) into
+         * Linux PRNG.
+         *
+         * Concurrency: Read requests to the underlying Linux PRNG are
+         * serialized (on sLock) to ensure that multiple threads do not get
+         * duplicated PRNG output.
+         */
+
+        private static final File URANDOM_FILE = new File("/dev/urandom");
+
+        private static final Object sLock = new Object();
+
+        /**
+         * Input stream for reading from Linux PRNG or {@code null} if not yet
+         * opened.
+         *
+         * @GuardedBy("sLock")
+         */
+        private static DataInputStream sUrandomIn;
+
+        /**
+         * Output stream for writing to Linux PRNG or {@code null} if not yet
+         * opened.
+         *
+         * @GuardedBy("sLock")
+         */
+        private static OutputStream sUrandomOut;
+
+        /**
+         * Whether this engine instance has been seeded. This is needed because
+         * each instance needs to seed itself if the client does not explicitly
+         * seed it.
+         */
+        private boolean mSeeded;
+
+        @Override
+        protected void engineSetSeed(byte[] bytes) {
+            try {
+                OutputStream out;
+                synchronized (sLock) {
+                    out = getUrandomOutputStream();
+                }
+                out.write(bytes);
+                out.flush();
+            } catch (IOException e) {
+                // On a small fraction of devices /dev/urandom is not writable.
+                // Log and ignore.
+                Log.w(PRNGFixes.class.getSimpleName(),
+                        "Failed to mix seed into " + URANDOM_FILE);
+            } finally {
+                mSeeded = true;
+            }
+        }
+
+        @Override
+        protected void engineNextBytes(byte[] bytes) {
+            if (!mSeeded) {
+                // Mix in the device- and invocation-specific seed.
+                engineSetSeed(generateSeed());
+            }
+
+            try {
+                DataInputStream in;
+                synchronized (sLock) {
+                    in = getUrandomInputStream();
+                }
+                synchronized (in) {
+                    in.readFully(bytes);
+                }
+            } catch (IOException e) {
+                throw new SecurityException(
+                        "Failed to read from " + URANDOM_FILE, e);
+            }
+        }
+
+        @Override
+        protected byte[] engineGenerateSeed(int size) {
+            byte[] seed = new byte[size];
+            engineNextBytes(seed);
+            return seed;
+        }
+
+        private DataInputStream getUrandomInputStream() {
+            synchronized (sLock) {
+                if (sUrandomIn == null) {
+                    // NOTE: Consider inserting a BufferedInputStream between
+                    // DataInputStream and FileInputStream if you need higher
+                    // PRNG output performance and can live with future PRNG
+                    // output being pulled into this process prematurely.
+                    try {
+                        sUrandomIn = new DataInputStream(
+                                new FileInputStream(URANDOM_FILE));
+                    } catch (IOException e) {
+                        throw new SecurityException("Failed to open "
+                                + URANDOM_FILE + " for reading", e);
+                    }
+                }
+                return sUrandomIn;
+            }
+        }
+
+        private OutputStream getUrandomOutputStream() throws IOException {
+            synchronized (sLock) {
+                if (sUrandomOut == null) {
+                    sUrandomOut = new FileOutputStream(URANDOM_FILE);
+                }
+                return sUrandomOut;
+            }
+        }
+    }
+
+    /**
+     * Generates a device- and invocation-specific seed to be mixed into the
+     * Linux PRNG.
+     */
+    private static byte[] generateSeed() {
+        try {
+            ByteArrayOutputStream seedBuffer = new ByteArrayOutputStream();
+            DataOutputStream seedBufferOut =
+                    new DataOutputStream(seedBuffer);
+            seedBufferOut.writeLong(System.currentTimeMillis());
+            seedBufferOut.writeLong(System.nanoTime());
+            seedBufferOut.writeInt(Process.myPid());
+            seedBufferOut.writeInt(Process.myUid());
+            seedBufferOut.write(BUILD_FINGERPRINT_AND_DEVICE_SERIAL);
+            seedBufferOut.close();
+            return seedBuffer.toByteArray();
+        } catch (IOException e) {
+            throw new SecurityException("Failed to generate seed", e);
+        }
+    }
+
+    /**
+     * Gets the hardware serial number of this device.
+     *
+     * @return serial number or {@code null} if not available.
+     */
+    private static String getDeviceSerialNumber() {
+        // We're using the Reflection API because Build.SERIAL is only available
+        // since API Level 9 (Gingerbread, Android 2.3).
+        try {
+            return (String) Build.class.getField("SERIAL").get(null);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static byte[] getBuildFingerprintAndDeviceSerial() {
+        StringBuilder result = new StringBuilder();
+        String fingerprint = Build.FINGERPRINT;
+        if (fingerprint != null) {
+            result.append(fingerprint);
+        }
+        String serial = getDeviceSerialNumber();
+        if (serial != null) {
+            result.append(serial);
+        }
+        try {
+            return result.toString().getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("UTF-8 encoding not supported");
+        }
+    }
+}

--- a/term/src/main/java/jackpal/androidterm/shortcuts/AddShortcut.java
+++ b/term/src/main/java/jackpal/androidterm/shortcuts/AddShortcut.java
@@ -10,6 +10,7 @@ import android.net.        Uri;
 import android.os.         Bundle;
 import android.os.         Environment;
 import android.preference. PreferenceManager;
+import android.util.       Log;
 import android.view.       Gravity;
 import android.view.       View;
 import android.view.       View.OnFocusChangeListener;
@@ -22,7 +23,9 @@ import android.widget.     EditText;
 import jackpal.androidterm.R;
 import jackpal.androidterm.RemoteInterface;
 import jackpal.androidterm.RunShortcut;
+import jackpal.androidterm.TermDebug;
 import jackpal.androidterm.compat.AlertDialogCompat;
+import jackpal.androidterm.compat.PRNGFixes;
 import jackpal.androidterm.util.ShortcutEncryption;
 
 import java.io.            File;
@@ -220,6 +223,8 @@ public class      AddShortcut
     , int    shortcutColor
     )
     {
+      // Apply workarounds for SecureRandom bugs in Android < 4.4
+      PRNGFixes.apply();
       ShortcutEncryption.Keys keys=ShortcutEncryption.getKeys(context);
       if(keys==null)
       {
@@ -229,7 +234,7 @@ public class      AddShortcut
         }
         catch (GeneralSecurityException e)
         {
-          // XXX
+          Log.e(TermDebug.LOG_TAG, "Generating shortcut encryption keys failed: " + e.toString());
           throw new RuntimeException(e);
         }
         ShortcutEncryption.saveKeys(context, keys);
@@ -245,7 +250,7 @@ public class      AddShortcut
       }
       catch (GeneralSecurityException e)
       {
-        // XXX
+        Log.e(TermDebug.LOG_TAG, "Shortcut encryption failed: " + e.toString());
         throw new RuntimeException(e);
       }
       Intent target=  new Intent().setClass(context, RunShortcut.class);


### PR DESCRIPTION
These patches contain various improvements to the encrypted shortcut code:

* Add workarounds for weak PRNGs on Android before 4.4, and use those workarounds before generating keys or encrypting
* Address review comments on the original patch (thanks!)
* Don't leave the terminal service running if it was only started in response to a failed shortcut intent

The very paranoid who are using Android 4.3 or earlier should regenerate their keys and recreate their shortcuts to ensure that the generated keys are truly random.  Unfortunately, I can't think of a way of forcing keys to be regenerated at the moment short of clearing data.  (I tend to think that exploiting key generation, even with a bad PRNG, has much too high a cost to be practical given the low return on investment for the attacker.)

Tested on various emulators and a device running 4.4.  I have test harness code that can generate encrypted shortcuts for use with "am start"; with that, I've tested that the code rejects corrupted shortcuts, shortcuts generated with incorrect keys, and shortcuts encrypted with the wrong key (with correct MAC).  (I'm not sure what to do with the test code, since it's intended for use on the desktop, and therefore requires removing the Android-specific parts of the shortcut encryption code before it will build.)