### PR TITLE
A bit of cleanup and refactoring in libtermexec and related native code.

### DIFF
--- a/libtermexec/build.gradle
+++ b/libtermexec/build.gradle
@@ -23,7 +23,7 @@ android {
         versionName "1.0"
 
         ndk {
-            moduleName 'libjackpal-termexec'
+            moduleName 'libjackpal-termexec2'
             abiFilters 'all'
             ldLibs 'log', 'c'
         }

--- a/libtermexec/src/main/java/jackpal/androidterm/TermExec.java
+++ b/libtermexec/src/main/java/jackpal/androidterm/TermExec.java
@@ -1,9 +1,6 @@
 package jackpal.androidterm;
 
 import android.annotation.TargetApi;
-import android.app.PendingIntent;
-import android.content.BroadcastReceiver;
-import android.content.IntentSender;
 import android.os.*;
 import android.support.annotation.NonNull;
 import java.io.FileDescriptor;
@@ -11,17 +8,26 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.*;
 
+/**
+ * Utility methods for creating and managing a subprocess. This class differs from
+ * {@link java.lang.ProcessBuilder} in that a pty is used to communicate with the subprocess.
+ * <p>
+ * Pseudo-terminals are a powerful Unix feature, that allows programs to interact with other programs
+ * they start in slightly more human-like way. For example, a pty owner can send ^C (aka SIGINT)
+ * to attached shell, even if said shell runs under a different user ID.
+ */
 public class TermExec {
+    // Warning: bump the library revision, when an incompatible change happens
+    static {
+        System.loadLibrary("jackpal-termexec2");
+    }
+
     public static final String SERVICE_ACTION_V1 = "jackpal.androidterm.action.START_TERM.v1";
 
     private static Field descriptorField;
 
     private final List<String> command;
     private final Map<String, String> environment;
-
-    static {
-        System.loadLibrary("jackpal-termexec");
-    }
 
     public TermExec(@NonNull String... command) {
         this(new ArrayList<>(Arrays.asList(command)));
@@ -50,6 +56,16 @@ public class TermExec {
         return this;
     }
 
+    /**
+     * Start the process and attach it to the pty, corresponding to given file descriptor.
+     * You have to obtain this file descriptor yourself by calling
+     * {@link android.os.ParcelFileDescriptor#open} on special terminal multiplexer
+     * device (located at /dev/ptmx).
+     * <p>
+     * Callers are responsible for closing the descriptor.
+     *
+     * @return the PID of the started process.
+     */
     public int start(@NonNull ParcelFileDescriptor ptmxFd) throws IOException {
         if (Looper.getMainLooper() == Looper.myLooper())
             throw new IllegalStateException("This method must not be called from the main thread!");
@@ -68,7 +84,19 @@ public class TermExec {
         return createSubprocess(ptmxFd, cmd, cmdArray, envArray);
     }
 
+    /**
+     * Causes the calling thread to wait for the process associated with the
+     * receiver to finish executing.
+     *
+     * @return The exit value of the Process being waited on
+     */
     public static native int waitFor(int processId);
+
+    /**
+     * Send signal via the "kill" system call. Android {@link android.os.Process#sendSignal} does not
+     * allow negative numbers (denoting process groups) to be used.
+     */
+    public static native void sendSignal(int processId, int signal);
 
     static int createSubprocess(ParcelFileDescriptor masterFd, String cmd, String[] args, String[] envVars) throws IOException
     {

--- a/libtermexec/src/main/jni/process.cpp
+++ b/libtermexec/src/main/jni/process.cpp
@@ -179,6 +179,12 @@ static int create_subprocess(JNIEnv *env, const char *cmd, char *const argv[], c
 
 extern "C" {
 
+JNIEXPORT void JNICALL Java_jackpal_androidterm_TermExec_sendSignal(JNIEnv *env, jobject clazz,
+    jint procId, jint signal)
+{
+    kill(procId, signal);
+}
+
 JNIEXPORT jint JNICALL Java_jackpal_androidterm_TermExec_waitFor(JNIEnv *env, jclass clazz, jint procId) {
     int status;
     waitpid(procId, &status, 0);

--- a/term/build.gradle
+++ b/term/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion 11
 
         ndk {
-            moduleName "libjackpal-androidterm4"
+            moduleName "libjackpal-androidterm5"
             abiFilters 'armeabi', 'mips', 'x86'
             ldLibs "log"
         }

--- a/term/src/main/java/jackpal/androidterm/TermService.java
+++ b/term/src/main/java/jackpal/androidterm/TermService.java
@@ -168,6 +168,9 @@ public class TermService extends Service implements TermSession.FinishCallback
                                 session.setFinishCallback(new RBinderCleanupCallback(result, callback));
                                 session.setTitle("");
 
+                                // TODO: handle the situation, when supplied file descriptor does not originate from
+                                // /dev/ptmx (probably should be implemented by throwing IllegalStateEXception
+                                // when recognized specific errno values in native Exec methods)
                                 session.initializeEmulator(80, 24);
                             }
                         });


### PR DESCRIPTION
Moved former native hangupProcessGroup into TermExec as sendSignal. Added some documentation,
that was accidentally removed in 13a90130e1a4bdb351aabc31952f28a0302b5d7e. Bump version numbers
of native libraries to fix #401 and #403 (an ABI compatibility issue, encountered by firmware
developers and people, using ATE as a system app).