### PR TITLE
check for null value in mActionBar when pressing the back key

### DIFF
--- a/term/src/main/java/jackpal/androidterm/Term.java
+++ b/term/src/main/java/jackpal/androidterm/Term.java
@@ -305,7 +305,7 @@ public class Term extends Activity implements UpdateCallback {
          * Make sure the back button always leaves the application.
          */
         private boolean backkeyInterceptor(int keyCode, KeyEvent event) {
-            if (keyCode == KeyEvent.KEYCODE_BACK && mActionBarMode == TermSettings.ACTION_BAR_MODE_HIDES && mActionBar.isShowing()) {
+            if (keyCode == KeyEvent.KEYCODE_BACK && mActionBarMode == TermSettings.ACTION_BAR_MODE_HIDES && mActionBar != null && mActionBar.isShowing()) {
                 /* We need to intercept the key event before the view sees it,
                    otherwise the view will handle it before we get it */
                 onKeyUp(keyCode, event);
@@ -947,7 +947,7 @@ public class Term extends Activity implements UpdateCallback {
                 }
                 mBackKeyPressed = false;
             }
-            if (mActionBarMode == TermSettings.ACTION_BAR_MODE_HIDES && mActionBar.isShowing()) {
+            if (mActionBarMode == TermSettings.ACTION_BAR_MODE_HIDES && mActionBar != null && mActionBar.isShowing()) {
                 mActionBar.hide();
                 return true;
             }


### PR DESCRIPTION
fixing issue #410, checking for null values in `mActionBar` before checking the status, preventing the handlers to throw a NullPointerException when checking for Action bar visibility with `mActionBar.isShowing()`