### PR TITLE
Install Android Support Repository when installing from CLI

### DIFF
--- a/tools/install-sdk-packages
+++ b/tools/install-sdk-packages
@@ -20,4 +20,4 @@ ANDROID="$ANDROID_SDK_ROOT/tools/android"
 # The update sdk command takes a comma-separated list of packages to install.
 # Installing them all at once may simplify the process of agreeing to licenses.
 
-$ANDROID update sdk -u -a -t android-11
+$ANDROID update sdk -u -a -t android-11,extra-android-m2repository


### PR DESCRIPTION
Fixes #400, error message:

Could not resolve all dependencies for configuration ':libtermexec:_debugCompile'.