### PR TITLE
Toast position settings

### DIFF
--- a/term/src/main/java/jackpal/androidterm/Term.java
+++ b/term/src/main/java/jackpal/androidterm/Term.java
@@ -602,20 +602,7 @@ public class Term extends Activity implements UpdateCallback {
         }
         setRequestedOrientation(o);
 
-        int toastPosition=mSettings.getToastPosition();
-        switch (toastPosition) {
-            case 0: this.toastGravity = Gravity.TOP | Gravity.LEFT; break;
-            case 1: this.toastGravity = Gravity.TOP ; break;
-            case 2: this.toastGravity = Gravity.TOP | Gravity.RIGHT; break;
-
-            case 3: this.toastGravity = Gravity.LEFT; break;
-            case 4: this.toastGravity = Gravity.CENTER; break;
-            case 5: this.toastGravity = Gravity.RIGHT; break;
-
-            case 6: this.toastGravity = Gravity.BOTTOM | Gravity.LEFT; break;
-            case 7: this.toastGravity = Gravity.BOTTOM ; break;
-            case 8: this.toastGravity = Gravity.BOTTOM | Gravity.RIGHT; break;
-        }
+        this.toastGravity=mSettings.getToastGravity();
 
     }
 

--- a/term/src/main/java/jackpal/androidterm/Term.java
+++ b/term/src/main/java/jackpal/androidterm/Term.java
@@ -101,6 +101,9 @@ public class Term extends Activity implements UpdateCallback {
     private final static int SEND_CONTROL_KEY_ID = 3;
     private final static int SEND_FN_KEY_ID = 4;
 
+    /// Preferred toast gravity setting
+    protected int toastGravity=Gravity.CENTER;
+
     private boolean mAlreadyStarted = false;
     private boolean mStopServiceOnFinish = false;
 
@@ -117,6 +120,7 @@ public class Term extends Activity implements UpdateCallback {
     private static final int WIFI_MODE_FULL_HIGH_PERF = 3;
 
     private boolean mBackKeyPressed;
+
 
     private static final String ACTION_PATH_BROADCAST = "jackpal.androidterm.broadcast.APPEND_TO_PATH";
     private static final String ACTION_PATH_PREPEND_BROADCAST = "jackpal.androidterm.broadcast.PREPEND_TO_PATH";
@@ -318,6 +322,7 @@ public class Term extends Activity implements UpdateCallback {
 
     private Handler mHandler = new Handler();
 
+
     @Override
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
@@ -421,7 +426,9 @@ public class Term extends Activity implements UpdateCallback {
                 try {
                     mTermSessions.add(createTermSession());
                 } catch (IOException e) {
-                    Toast.makeText(this, "Failed to start terminal session", Toast.LENGTH_LONG).show();
+                    Toast toast=Toast.makeText(this, "Failed to start terminal session", Toast.LENGTH_LONG);
+                    toast.setGravity(toastGravity,0,0);
+                    toast.show();
                     finish();
                     return;
                 }
@@ -594,6 +601,22 @@ public class Term extends Activity implements UpdateCallback {
             /* Shouldn't be happened. */
         }
         setRequestedOrientation(o);
+
+        int toastPosition=mSettings.getToastPosition();
+        switch (toastPosition) {
+            case 0: this.toastGravity = Gravity.TOP | Gravity.LEFT; break;
+            case 1: this.toastGravity = Gravity.TOP ; break;
+            case 2: this.toastGravity = Gravity.TOP | Gravity.RIGHT; break;
+
+            case 3: this.toastGravity = Gravity.LEFT; break;
+            case 4: this.toastGravity = Gravity.CENTER; break;
+            case 5: this.toastGravity = Gravity.RIGHT; break;
+
+            case 6: this.toastGravity = Gravity.BOTTOM | Gravity.LEFT; break;
+            case 7: this.toastGravity = Gravity.BOTTOM ; break;
+            case 8: this.toastGravity = Gravity.BOTTOM | Gravity.RIGHT; break;
+        }
+
     }
 
     @Override
@@ -722,7 +745,7 @@ public class Term extends Activity implements UpdateCallback {
         } else if (id == R.id.menu_reset) {
             doResetTerminal();
             Toast toast = Toast.makeText(this,R.string.reset_toast_notification,Toast.LENGTH_LONG);
-            toast.setGravity(Gravity.CENTER, 0, 0);
+            toast.setGravity(toastGravity, 0, 0);
             toast.show();
         } else if (id == R.id.menu_send_email) {
             doEmailTranscript();
@@ -763,7 +786,9 @@ public class Term extends Activity implements UpdateCallback {
             mViewFlipper.addView(view);
             mViewFlipper.setDisplayedChild(mViewFlipper.getChildCount()-1);
         } catch (IOException e) {
-            Toast.makeText(this, "Failed to create a session", Toast.LENGTH_SHORT).show();
+            Toast toast=Toast.makeText(this, "Failed to create a session", Toast.LENGTH_SHORT);
+            toast.setGravity(toastGravity,0,0);
+            toast.show();
         }
     }
 
@@ -1042,9 +1067,11 @@ public class Term extends Activity implements UpdateCallback {
                 startActivity(Intent.createChooser(intent,
                         getString(R.string.email_transcript_chooser_title)));
             } catch (ActivityNotFoundException e) {
-                Toast.makeText(this,
+                Toast toast=Toast.makeText(this,
                         R.string.email_transcript_no_email_activity_found,
-                        Toast.LENGTH_LONG).show();
+                        Toast.LENGTH_LONG);
+                toast.setGravity(toastGravity,0,0);
+                toast.show();
             }
         }
     }

--- a/term/src/main/java/jackpal/androidterm/TermViewFlipper.java
+++ b/term/src/main/java/jackpal/androidterm/TermViewFlipper.java
@@ -51,6 +51,7 @@ public class TermViewFlipper extends ViewFlipper implements Iterable<View> {
     private LayoutParams mChildParams = null;
     private boolean mRedoLayout = false;
 
+    private int mToastGravity=Gravity.CENTER;
     /**
      * True if we must poll to discover if the view has changed size.
      * This is the only known way to detect the view changing size due to
@@ -85,8 +86,6 @@ public class TermViewFlipper extends ViewFlipper implements Iterable<View> {
     public TermViewFlipper(Context context) {
         super(context);
         commonConstructor(context);
-        mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
-        mSettings = new TermSettings(getResources(), mPrefs);
 
     }
 
@@ -110,6 +109,8 @@ public class TermViewFlipper extends ViewFlipper implements Iterable<View> {
         int[] colorScheme = settings.getColorScheme();
         setBackgroundColor(colorScheme[1]);
         mStatusBarVisible = statusBarVisible;
+
+        mToastGravity=settings.getToastGravity();
     }
 
     public Iterator<View> iterator() {
@@ -182,10 +183,11 @@ public class TermViewFlipper extends ViewFlipper implements Iterable<View> {
 
         if (mToast == null) {
             mToast = Toast.makeText(context, title, Toast.LENGTH_SHORT);
-            mToast.setGravity(Gravity.CENTER, 0, 0);
+
         } else {
             mToast.setText(title);
         }
+        mToast.setGravity(mToastGravity, 0, 0);
         mToast.show();
     }
 

--- a/term/src/main/java/jackpal/androidterm/TermViewFlipper.java
+++ b/term/src/main/java/jackpal/androidterm/TermViewFlipper.java
@@ -19,10 +19,12 @@ package jackpal.androidterm;
 import java.util.Iterator;
 import java.util.LinkedList;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.View;
@@ -83,6 +85,9 @@ public class TermViewFlipper extends ViewFlipper implements Iterable<View> {
     public TermViewFlipper(Context context) {
         super(context);
         commonConstructor(context);
+        mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+        mSettings = new TermSettings(getResources(), mPrefs);
+
     }
 
     public TermViewFlipper(Context context, AttributeSet attrs) {

--- a/term/src/main/java/jackpal/androidterm/util/TermSettings.java
+++ b/term/src/main/java/jackpal/androidterm/util/TermSettings.java
@@ -187,7 +187,7 @@ public class TermSettings {
         mAltSendsEsc = res.getBoolean(R.bool.pref_alt_sends_esc_default);
         mMouseTracking = res.getBoolean(R.bool.pref_mouse_tracking_default);
         mUseKeyboardShortcuts = res.getBoolean(R.bool.pref_use_keyboard_shortcuts_default);
-        mToastPosition = res.getInteger(R.integer.perf_toast_position_default);
+        mToastPosition = res.getInteger(R.integer.pref_toast_position_default);
     }
 
     public void readPrefs(SharedPreferences prefs) {

--- a/term/src/main/java/jackpal/androidterm/util/TermSettings.java
+++ b/term/src/main/java/jackpal/androidterm/util/TermSettings.java
@@ -20,6 +20,7 @@ import jackpal.androidterm.R;
 
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.view.Gravity;
 import android.view.KeyEvent;
 
 /**
@@ -217,7 +218,7 @@ public class TermSettings {
         mMouseTracking = readBooleanPref(MOUSE_TRACKING, mMouseTracking);
         mUseKeyboardShortcuts = readBooleanPref(USE_KEYBOARD_SHORTCUTS,
                 mUseKeyboardShortcuts);
-        mToastPosition = readIntPref(TOAST_POSITION, mToastPosition,TOAST_POSITION_MAX);
+        mToastPosition = readIntPref(TOAST_POSITION, mToastPosition, TOAST_POSITION_MAX);
         mPrefs = null;  // we leak a Context if we hold on to this
     }
 
@@ -378,4 +379,22 @@ public class TermSettings {
     }
 
     public int getToastPosition() { return mToastPosition; }
+
+    public int getToastGravity() {
+        int result= Gravity.CENTER;
+        switch (getToastPosition()) {
+            case 0: result = Gravity.TOP | Gravity.LEFT; break;
+            case 1: result = Gravity.TOP ; break;
+            case 2: result = Gravity.TOP | Gravity.RIGHT; break;
+
+            case 3: result = Gravity.LEFT; break;
+            case 4: result = Gravity.CENTER; break;
+            case 5: result = Gravity.RIGHT; break;
+
+            case 6: result = Gravity.BOTTOM | Gravity.LEFT; break;
+            case 7: result = Gravity.BOTTOM ; break;
+            case 8: result = Gravity.BOTTOM | Gravity.RIGHT; break;
+        }
+        return result;
+    }
 }

--- a/term/src/main/java/jackpal/androidterm/util/TermSettings.java
+++ b/term/src/main/java/jackpal/androidterm/util/TermSettings.java
@@ -17,7 +17,6 @@
 package jackpal.androidterm.util;
 
 import jackpal.androidterm.R;
-import jackpal.androidterm.compat.AndroidCompat;
 
 import android.content.SharedPreferences;
 import android.content.res.Resources;
@@ -60,6 +59,10 @@ public class TermSettings {
 
     private boolean mUseKeyboardShortcuts;
 
+    private int mToastPosition = 4;
+
+    private static final int TOAST_POSITION_MAX=8;
+
     private static final String STATUSBAR_KEY = "statusbar";
     private static final String ACTIONBAR_KEY = "actionbar";
     private static final String ORIENTATION_KEY = "orientation";
@@ -81,6 +84,7 @@ public class TermSettings {
     private static final String ALT_SENDS_ESC = "alt_sends_esc";
     private static final String MOUSE_TRACKING = "mouse_tracking";
     private static final String USE_KEYBOARD_SHORTCUTS = "use_keyboard_shortcuts";
+    private static final String TOAST_POSITION = "toast_position";
 
     public static final int WHITE               = 0xffffffff;
     public static final int BLACK               = 0xff000000;
@@ -182,6 +186,7 @@ public class TermSettings {
         mAltSendsEsc = res.getBoolean(R.bool.pref_alt_sends_esc_default);
         mMouseTracking = res.getBoolean(R.bool.pref_mouse_tracking_default);
         mUseKeyboardShortcuts = res.getBoolean(R.bool.pref_use_keyboard_shortcuts_default);
+        mToastPosition = res.getInteger(R.integer.perf_toast_position_default);
     }
 
     public void readPrefs(SharedPreferences prefs) {
@@ -212,6 +217,7 @@ public class TermSettings {
         mMouseTracking = readBooleanPref(MOUSE_TRACKING, mMouseTracking);
         mUseKeyboardShortcuts = readBooleanPref(USE_KEYBOARD_SHORTCUTS,
                 mUseKeyboardShortcuts);
+        mToastPosition = readIntPref(TOAST_POSITION, mToastPosition,TOAST_POSITION_MAX);
         mPrefs = null;  // we leak a Context if we hold on to this
     }
 
@@ -370,4 +376,6 @@ public class TermSettings {
     public String getHomePath() {
         return mHomePath;
     }
+
+    public int getToastPosition() { return mToastPosition; }
 }

--- a/term/src/main/res/values/arrays.xml
+++ b/term/src/main/res/values/arrays.xml
@@ -33,6 +33,20 @@
         <item>Portrait</item>
     </string-array>
 
+    <string-array name="entries_toast_position">
+        <item>Top-Left</item>
+        <item>Top-Center</item>
+        <item>Top-Right</item>
+
+        <item>Middle-Left</item>
+        <item>Middle-Center</item>
+        <item>Middle-Right</item>
+
+        <item>Bottom-Left</item>
+        <item>Bottom-Center</item>
+        <item>Bottom-Right</item>
+    </string-array>
+
     <string-array name="entries_cursorblink_preference">
         <item>Non-blinking cursor</item>
         <item>Blinking cursor</item>

--- a/term/src/main/res/values/arraysNoLocalize.xml
+++ b/term/src/main/res/values/arraysNoLocalize.xml
@@ -35,6 +35,20 @@
         <item>2</item>
     </string-array>
 
+    <string-array name="entryvalues_toast_position">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+    </string-array>
+
     <string-array name="entryvalues_cursorblink_preference">
         <item>0</item>
         <item>1</item>

--- a/term/src/main/res/values/defaults.xml
+++ b/term/src/main/res/values/defaults.xml
@@ -4,7 +4,7 @@
    <string name="pref_statusbar_default" translatable="false">1</string>
    <integer name="pref_actionbar_default">1</integer>
    <integer name="pref_orientation_default">0</integer>
-   <integer name="perf_toast_position_default">4</integer>
+   <integer name="pref_toast_position_default">4</integer>
    <string name="pref_cursorstyle_default" translatable="false">0</string>
    <string name="pref_cursorblink_default" translatable="false">0</string>
    <string name="pref_fontsize_default" translatable="false">10</string>

--- a/term/src/main/res/values/defaults.xml
+++ b/term/src/main/res/values/defaults.xml
@@ -4,6 +4,7 @@
    <string name="pref_statusbar_default" translatable="false">1</string>
    <integer name="pref_actionbar_default">1</integer>
    <integer name="pref_orientation_default">0</integer>
+   <integer name="perf_toast_position_default">4</integer>
    <string name="pref_cursorstyle_default" translatable="false">0</string>
    <string name="pref_cursorblink_default" translatable="false">0</string>
    <string name="pref_fontsize_default" translatable="false">10</string>

--- a/term/src/main/res/values/strings.xml
+++ b/term/src/main/res/values/strings.xml
@@ -62,6 +62,10 @@
    <string name="summary_orientation_preference">Choose the screen orientation behavior.</string>
    <string name="dialog_title_orientation_preference">Screen orientation behavior</string>
 
+   <string name="title_toast_position">Notification position</string>
+   <string name="summary_toast_position">Choose the position for the toast notification to show up.</string>
+   <string name="dialog_title_toast_position">Choose the toast notification position</string>
+
    <string name="title_cursorstyle_preference">Cursor style</string>
    <string name="summary_cursorstyle_preference">Choose cursor style.</string>
    <string name="dialog_title_cursorstyle_preference">Cursor style</string>

--- a/term/src/main/res/xml/preferences.xml
+++ b/term/src/main/res/xml/preferences.xml
@@ -51,7 +51,7 @@
         <ListPreference
                 android:key="toast_position"
                 android:defaultValue="4"
-                android:title="notification position"
+                android:title="Notification position"
                 android:summary="Choose the position for the toast notification to show up."
                 android:entries="@array/entries_toast_position"
                 android:entryValues="@array/entryvalues_toast_position"

--- a/term/src/main/res/xml/preferences.xml
+++ b/term/src/main/res/xml/preferences.xml
@@ -48,6 +48,15 @@
                 android:entryValues="@array/entryvalues_orientation_preference"
                 android:dialogTitle="@string/dialog_title_orientation_preference" />
 
+        <ListPreference
+                android:key="toast_position"
+                android:defaultValue="4"
+                android:title="notification position"
+                android:summary="Choose the position for the toast notification to show up."
+                android:entries="@array/entries_toast_position"
+                android:entryValues="@array/entryvalues_toast_position"
+                android:dialogTitle="Choose the toast notification position"
+            />
 <!--
         <ListPreference
                 android:key="cursorstyle"

--- a/term/src/main/res/xml/preferences.xml
+++ b/term/src/main/res/xml/preferences.xml
@@ -50,13 +50,12 @@
 
         <ListPreference
                 android:key="toast_position"
-                android:defaultValue="4"
-                android:title="Notification position"
-                android:summary="Choose the position for the toast notification to show up."
+                android:defaultValue="@integer/pref_toast_position_default"
+                android:title="@string/title_toast_position"
+                android:summary="@string/summary_toast_position"
                 android:entries="@array/entries_toast_position"
                 android:entryValues="@array/entryvalues_toast_position"
-                android:dialogTitle="Choose the toast notification position"
-            />
+                android:dialogTitle="@string/dialog_title_toast_position" />
 <!--
         <ListPreference
                 android:key="cursorstyle"


### PR DESCRIPTION
Feature request #339 
The toast could momentary hide **important** content in the middle of the terminal screen.
toast position setting in the preferences, with a list preference 
Translation where possible to follow.

it would be *great* to have a preference list with image, but surely overkill