### PR TITLE
Custom font settings

### DIFF
--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/CustomFontPaintRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/CustomFontPaintRenderer.java
@@ -16,54 +16,17 @@
 
 package jackpal.androidterm.emulatorview;
 
-import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.util.FloatMath;
-import android.content.Context;
-import android.os.Environment;
-import android.util.Log;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-
-import jackpal.androidterm.emulatorview.compat.TypefaceCompat;
 
 
 class CustomFontPaintRenderer extends PaintRenderer {
 
-    protected String readFile(File input) throws IOException{
-        try(BufferedReader reader=new BufferedReader(new FileReader(input))) {
-            Log.i("CustomFontPaintRenderer","read font name");
-            return reader.readLine();
-        }catch (IOException ex) {
-            throw new IOException(ex);
-        }
-    }
-
-    public CustomFontPaintRenderer(int fontSize, ColorScheme scheme) {
+    public CustomFontPaintRenderer(int fontSize, ColorScheme scheme, Typeface face) {
         super(scheme);
-        File path=new File(Environment.getExternalStorageDirectory(),"jackpal.androidterm.emulatorview.typeface.txt");
-
-
-        Typeface face = Typeface.MONOSPACE;
-
-        if(path.exists() && path.isFile()) {
-            try {
-                String filename = readFile(path);
-                File fontFilePath = new File(filename);
-                if (fontFilePath.exists() && fontFilePath.exists()) {
-                    face = TypefaceCompat.createFromFile(fontFilePath);
-                }
-            }catch (IOException ex) {
-
-                Log.e(CustomFontPaintRenderer.class.getName(),"error loading font",ex);
-            }
-        }
+        //Typeface face = typeface;
 
         mTextPaint = new Paint();
         mTextPaint.setTypeface(face);
@@ -74,5 +37,6 @@ class CustomFontPaintRenderer extends PaintRenderer {
         mCharAscent = (int) FloatMath.ceil(mTextPaint.ascent());
         mCharDescent = mCharHeight + mCharAscent;
         mCharWidth = mTextPaint.measureText(EXAMPLE_CHAR, 0, 1);
+
     }
 }

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/CustomFontPaintRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/CustomFontPaintRenderer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jackpal.androidterm.emulatorview;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Typeface;
+import android.util.FloatMath;
+import android.content.Context;
+import android.os.Environment;
+import android.util.Log;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+
+class CustomFontPaintRenderer extends PaintRenderer {
+
+    protected String readFile(File input) throws IOException{
+        try(BufferedReader reader=new BufferedReader(new FileReader(input))) {
+            return reader.readLine();
+        }catch (IOException ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    public CustomFontPaintRenderer(int fontSize, ColorScheme scheme) {
+        super(scheme);
+        File path=new File(Environment.getExternalStorageDirectory(),"jackpal.androidterm.emulatorview.typeface.txt");
+
+
+        Typeface face = Typeface.MONOSPACE;
+
+        if(path.exists() && path.isFile()) {
+            try {
+                String filename = readFile(path);
+                File fontFilePath = new File(filename);
+                if (fontFilePath.exists() && fontFilePath.exists()) {
+                    face = Typeface.createFromFile(fontFilePath);
+                }
+            }catch (IOException ex) {
+
+                Log.e(CustomFontPaintRenderer.class.getName(),"error loading font",ex);
+            }
+        }
+
+        mTextPaint = new Paint();
+        mTextPaint.setTypeface(face);
+        mTextPaint.setAntiAlias(true);
+        mTextPaint.setTextSize(fontSize);
+
+        mCharHeight = (int) FloatMath.ceil(mTextPaint.getFontSpacing());
+        mCharAscent = (int) FloatMath.ceil(mTextPaint.ascent());
+        mCharDescent = mCharHeight + mCharAscent;
+        mCharWidth = mTextPaint.measureText(EXAMPLE_CHAR, 0, 1);
+    }
+}

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/CustomFontPaintRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/CustomFontPaintRenderer.java
@@ -31,11 +31,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 
+import jackpal.androidterm.emulatorview.compat.TypefaceCompat;
+
 
 class CustomFontPaintRenderer extends PaintRenderer {
 
     protected String readFile(File input) throws IOException{
         try(BufferedReader reader=new BufferedReader(new FileReader(input))) {
+            Log.i("CustomFontPaintRenderer","read font name");
             return reader.readLine();
         }catch (IOException ex) {
             throw new IOException(ex);
@@ -54,7 +57,7 @@ class CustomFontPaintRenderer extends PaintRenderer {
                 String filename = readFile(path);
                 File fontFilePath = new File(filename);
                 if (fontFilePath.exists() && fontFilePath.exists()) {
-                    face = Typeface.createFromFile(fontFilePath);
+                    face = TypefaceCompat.createFromFile(fontFilePath);
                 }
             }catch (IOException ex) {
 

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/EmulatorView.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/EmulatorView.java
@@ -1432,7 +1432,7 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
     private void updateText() {
         ColorScheme scheme = mColorScheme;
         if (mTextSize > 0) {
-            mTextRenderer = new PaintRenderer(mTextSize, scheme);
+            mTextRenderer = new CustomFontPaintRenderer(mTextSize, scheme);
         }
         else {
             mTextRenderer = new Bitmap4x8FontRenderer(getResources(), scheme);

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/EmulatorView.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/EmulatorView.java
@@ -28,6 +28,7 @@ import java.util.Hashtable;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -113,6 +114,11 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
      * Color scheme (default foreground/background colors).
      */
     private ColorScheme mColorScheme = BaseTextRenderer.defaultColorScheme;
+
+    /**
+     * Typeface
+     */
+    private Typeface mTypeface = Typeface.MONOSPACE;
 
     private Paint mForegroundPaint;
 
@@ -617,6 +623,21 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
             mColorScheme = BaseTextRenderer.defaultColorScheme;
         } else {
             mColorScheme = scheme;
+        }
+        updateText();
+    }
+
+    /**
+     * Set the <code>EmulatorView</code> Typeface.
+     *
+     * @param typeface the {@link Typeface} to use (use null for Typeface.MONOSPACE).
+     */
+    public void setmTypeface(Typeface typeface) {
+
+        if(typeface==null) {
+            mTypeface=Typeface.MONOSPACE;
+        }else{
+            mTypeface=typeface;
         }
         updateText();
     }
@@ -1432,7 +1453,7 @@ public class EmulatorView extends View implements GestureDetector.OnGestureListe
     private void updateText() {
         ColorScheme scheme = mColorScheme;
         if (mTextSize > 0) {
-            mTextRenderer = new CustomFontPaintRenderer(mTextSize, scheme);
+            mTextRenderer = new CustomFontPaintRenderer(mTextSize, scheme,mTypeface);
         }
         else {
             mTextRenderer = new Bitmap4x8FontRenderer(getResources(), scheme);

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/PaintRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/PaintRenderer.java
@@ -21,7 +21,6 @@ import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.util.FloatMath;
 
-
 class PaintRenderer extends BaseTextRenderer {
     public PaintRenderer(int fontSize, ColorScheme scheme) {
         super(scheme);
@@ -34,6 +33,10 @@ class PaintRenderer extends BaseTextRenderer {
         mCharAscent = (int) FloatMath.ceil(mTextPaint.ascent());
         mCharDescent = mCharHeight + mCharAscent;
         mCharWidth = mTextPaint.measureText(EXAMPLE_CHAR, 0, 1);
+    }
+
+    protected PaintRenderer(ColorScheme scheme) {
+        super(scheme);
     }
 
     public void drawTextRun(Canvas canvas, float x, float y, int lineOffset,
@@ -137,10 +140,10 @@ class PaintRenderer extends BaseTextRenderer {
         return mCharDescent;
     }
 
-    private Paint mTextPaint;
-    private float mCharWidth;
-    private int mCharHeight;
-    private int mCharAscent;
-    private int mCharDescent;
-    private static final char[] EXAMPLE_CHAR = {'X'};
+    protected Paint mTextPaint;
+    protected float mCharWidth;
+    protected int mCharHeight;
+    protected int mCharAscent;
+    protected int mCharDescent;
+    protected static final char[] EXAMPLE_CHAR = {'X'};
 }

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/compat/TypefaceCompat.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/compat/TypefaceCompat.java
@@ -1,0 +1,25 @@
+package jackpal.androidterm.emulatorview.compat;
+
+import android.annotation.TargetApi;
+import android.graphics.Typeface;
+
+import java.io.File;
+
+/**
+ * Typeface creation shim
+ */
+
+public class TypefaceCompat {
+    private static class Api4OrLater {
+        @TargetApi(4)
+        public static Typeface createFromFile(File path) {
+            return Typeface.createFromFile(path);
+        }
+    }
+    public static Typeface createFromFile(File path) {
+        if(AndroidCompat.SDK < 4 ) {
+            return Typeface.MONOSPACE;
+        }
+        return Api4OrLater.createFromFile(path);
+    }
+}

--- a/term/src/main/java/jackpal/androidterm/TermPreferences.java
+++ b/term/src/main/java/jackpal/androidterm/TermPreferences.java
@@ -19,19 +19,42 @@ package jackpal.androidterm;
 import jackpal.androidterm.compat.ActionBarCompat;
 import jackpal.androidterm.compat.ActivityCompat;
 import jackpal.androidterm.compat.AndroidCompat;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
+import android.preference.PreferenceManager;
 import android.view.MenuItem;
+import android.widget.Toast;
+
+import java.io.File;
 
 public class TermPreferences extends PreferenceActivity {
     private static final String ACTIONBAR_KEY = "actionbar";
     private static final String CATEGORY_SCREEN_KEY = "screen";
 
+    private static final String CUSTOM_FONT_CHOOSER="custom_font_filepath";
+
+    private static final int RESULT_CODE_FONT_CHOOSER=1;
+
+
+    protected void updateFontSummary() {
+        Preference fontSelector=findPreference(CUSTOM_FONT_CHOOSER);
+        String currentFont= PreferenceManager.getDefaultSharedPreferences(this).getString(CUSTOM_FONT_CHOOSER, "");
+        if(currentFont=="") {
+            fontSelector.setSummary(this.getString(R.string.custom_font_filepath_summary));
+        }else{
+            fontSelector.setSummary(currentFont+" "+this.getString(R.string.custom_font_filepath_summary_reset));
+        }
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
 
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
@@ -53,7 +76,33 @@ public class TermPreferences extends PreferenceActivity {
                 bar.setDisplayOptions(ActionBarCompat.DISPLAY_HOME_AS_UP, ActionBarCompat.DISPLAY_HOME_AS_UP);
             }
         }
+
+        /// Init custom font chooser
+        Preference fontSelector=findPreference(CUSTOM_FONT_CHOOSER);
+        updateFontSummary();
+        final PreferenceActivity that=this;
+        fontSelector.setOnPreferenceClickListener(
+                new Preference.OnPreferenceClickListener() {
+                    @Override
+                    public boolean onPreferenceClick(Preference preference) {
+                        String currentFont= PreferenceManager.getDefaultSharedPreferences(that).getString(CUSTOM_FONT_CHOOSER, "");
+                        if(currentFont=="") {
+                            Intent intent = new Intent("android.intent.action.GET_CONTENT");
+                            intent.setType("*/*");
+                            startActivityForResult(intent, RESULT_CODE_FONT_CHOOSER);
+                        }else{
+                            SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(that).edit();
+                            editor.putString(CUSTOM_FONT_CHOOSER, "");
+                            editor.commit();
+                            updateFontSummary();
+                        }
+                        return true;
+                    }
+                }
+        );
     }
+
+
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -65,5 +114,25 @@ public class TermPreferences extends PreferenceActivity {
         default:
             return super.onOptionsItemSelected(item);
         }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+
+        if(resultCode==RESULT_OK) {
+            if(requestCode==RESULT_CODE_FONT_CHOOSER) {
+                String path= data.getData().getPath();
+                if(new File(path).exists()) {
+                    SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
+                    editor.putString(CUSTOM_FONT_CHOOSER, path);
+                    editor.commit();
+                    updateFontSummary();
+                }else{
+                    Toast.makeText(this,R.string.custom_font_filepath_summary_error,Toast.LENGTH_LONG).show();
+                }
+            }
+        }
+
+        super.onActivityResult(requestCode, resultCode, data);
     }
 }

--- a/term/src/main/java/jackpal/androidterm/TermPreferences.java
+++ b/term/src/main/java/jackpal/androidterm/TermPreferences.java
@@ -19,7 +19,9 @@ package jackpal.androidterm;
 import jackpal.androidterm.compat.ActionBarCompat;
 import jackpal.androidterm.compat.ActivityCompat;
 import jackpal.androidterm.compat.AndroidCompat;
+import jackpal.androidterm.compat.TypefaceCompat;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -27,6 +29,7 @@ import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.view.MenuItem;
 import android.widget.Toast;
 
@@ -36,19 +39,40 @@ public class TermPreferences extends PreferenceActivity {
     private static final String ACTIONBAR_KEY = "actionbar";
     private static final String CATEGORY_SCREEN_KEY = "screen";
 
-    private static final String CUSTOM_FONT_CHOOSER="custom_font_filepath";
+    private static final String CUSTOM_FONT_CHOOSER_KEY ="custom_font_filepath";
+    private static final String CATEGORY_TEXT_KEY = "text_category";
 
     private static final int RESULT_CODE_FONT_CHOOSER=1;
 
 
     protected void updateFontSummary() {
-        Preference fontSelector=findPreference(CUSTOM_FONT_CHOOSER);
-        String currentFont= PreferenceManager.getDefaultSharedPreferences(this).getString(CUSTOM_FONT_CHOOSER, "");
+        Preference fontSelector=findPreference(CUSTOM_FONT_CHOOSER_KEY);
+        String currentFont= PreferenceManager.getDefaultSharedPreferences(this).getString(CUSTOM_FONT_CHOOSER_KEY, "");
         if(currentFont=="") {
-            fontSelector.setSummary(this.getString(R.string.custom_font_filepath_summary));
+            fontSelector.setSummary(getString(R.string.custom_font_filepath_summary));
         }else{
-            fontSelector.setSummary(currentFont+" "+this.getString(R.string.custom_font_filepath_summary_reset));
+            fontSelector.setSummary(currentFont + " " + getString(R.string.custom_font_filepath_summary_reset));
         }
+    }
+
+    protected boolean tryIntent(String intentDescription) {
+        boolean result;
+        try {
+            Intent intent = new Intent(intentDescription);
+            intent.setType("*/*");
+            /*
+            File path = new File(Environment.getRootDirectory(), "fonts");
+            Log.d(TermPreferences.class.getName(),path.getAbsolutePath());
+            intent.setData(Uri.fromFile(path));
+            */
+            startActivityForResult(intent, RESULT_CODE_FONT_CHOOSER);
+
+            result=true;
+        }catch(ActivityNotFoundException ex) {
+            Log.e(TermPreferences.class.getName(),intentDescription,ex);
+            result=false;
+        }
+        return result;
     }
 
     @Override
@@ -62,11 +86,11 @@ public class TermPreferences extends PreferenceActivity {
         // Remove the action bar pref on older platforms without an action bar
         if (AndroidCompat.SDK < 11) {
             Preference actionBarPref = findPreference(ACTIONBAR_KEY);
-             PreferenceCategory screenCategory =
-                    (PreferenceCategory) findPreference(CATEGORY_SCREEN_KEY);
-             if ((actionBarPref != null) && (screenCategory != null)) {
-                 screenCategory.removePreference(actionBarPref);
-             }
+            PreferenceCategory screenCategory =
+                   (PreferenceCategory) findPreference(CATEGORY_SCREEN_KEY);
+            if ((actionBarPref != null) && (screenCategory != null)) {
+                screenCategory.removePreference(actionBarPref);
+            }
         }
 
         // Display up indicator on action bar home button
@@ -77,29 +101,48 @@ public class TermPreferences extends PreferenceActivity {
             }
         }
 
+
         /// Init custom font chooser
-        Preference fontSelector=findPreference(CUSTOM_FONT_CHOOSER);
-        updateFontSummary();
-        final PreferenceActivity that=this;
-        fontSelector.setOnPreferenceClickListener(
-                new Preference.OnPreferenceClickListener() {
-                    @Override
-                    public boolean onPreferenceClick(Preference preference) {
-                        String currentFont= PreferenceManager.getDefaultSharedPreferences(that).getString(CUSTOM_FONT_CHOOSER, "");
-                        if(currentFont=="") {
-                            Intent intent = new Intent("android.intent.action.GET_CONTENT");
-                            intent.setType("*/*");
-                            startActivityForResult(intent, RESULT_CODE_FONT_CHOOSER);
-                        }else{
-                            SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(that).edit();
-                            editor.putString(CUSTOM_FONT_CHOOSER, "");
-                            editor.commit();
-                            updateFontSummary();
-                        }
-                        return true;
-                    }
+        Preference fontSelector=findPreference(CUSTOM_FONT_CHOOSER_KEY);
+        if(fontSelector!=null) {
+            if (AndroidCompat.SDK < 4) {
+                PreferenceCategory textCategory = (PreferenceCategory) findPreference(CATEGORY_TEXT_KEY);
+                if(textCategory!=null) {
+                    textCategory.removePreference(fontSelector);
+                }else{
+                    Log.e(TermPreferences.class.getName(), "cannot find 'Text' preference category");
                 }
-        );
+            } else {
+                updateFontSummary();
+                final PreferenceActivity that = this;
+                fontSelector.setOnPreferenceClickListener(
+                        new Preference.OnPreferenceClickListener() {
+                            @Override
+                            public boolean onPreferenceClick(Preference preference) {
+                                String currentFont = PreferenceManager.getDefaultSharedPreferences(that).getString(CUSTOM_FONT_CHOOSER_KEY, "");
+                                if (currentFont == "") {
+                                    if(
+                                            !(tryIntent("android.intent.action.GET_CONTENT") || tryIntent("android.intent.action.PICK"))
+                                            ) {
+                                        // but it really should not happen at all !
+
+                                        Toast.makeText(that,R.string.custom_font_filepath_summary_error_filepicker_Intent,Toast.LENGTH_SHORT).show();
+                                        return false;
+                                    }
+                                } else {
+                                    SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(that).edit();
+                                    editor.putString(CUSTOM_FONT_CHOOSER_KEY, "");
+                                    editor.commit();
+                                    updateFontSummary();
+                                }
+                                return true;
+                            }
+                        }
+                );
+            }
+        }else{
+            Log.e(TermPreferences.class.getName(), "cannot find 'font selector' preference");
+        }
     }
 
 
@@ -116,19 +159,40 @@ public class TermPreferences extends PreferenceActivity {
         }
     }
 
+
+    protected boolean checkFile(String input) {
+        File path=new File(input);
+        boolean result=false;
+        if(path.exists() && path.isFile() &&
+                (path.getName().endsWith(".ttf") || path.getName().endsWith(".otf"))
+                ) {
+            if(TypefaceCompat.createFromFile(path,null)!=null) {
+                result=true;
+            }else{
+                Log.e(TermPreferences.class.getName(),"can not read the font file");
+            }
+        }else{
+            Log.e(TermPreferences.class.getName(),"invalid patgh");
+        }
+        return result;
+    }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 
         if(resultCode==RESULT_OK) {
             if(requestCode==RESULT_CODE_FONT_CHOOSER) {
+
                 String path= data.getData().getPath();
-                if(new File(path).exists()) {
+
+
+                if(checkFile(path)) {
                     SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
-                    editor.putString(CUSTOM_FONT_CHOOSER, path);
+                    editor.putString(CUSTOM_FONT_CHOOSER_KEY, path);
                     editor.commit();
                     updateFontSummary();
                 }else{
-                    Toast.makeText(this,R.string.custom_font_filepath_summary_error,Toast.LENGTH_LONG).show();
+                    Toast.makeText(this,R.string.custom_font_filepath_summary_error_filepicker,Toast.LENGTH_LONG).show();
                 }
             }
         }

--- a/term/src/main/java/jackpal/androidterm/TermView.java
+++ b/term/src/main/java/jackpal/androidterm/TermView.java
@@ -17,8 +17,12 @@
 package jackpal.androidterm;
 
 import android.content.Context;
+import android.graphics.Typeface;
 import android.util.DisplayMetrics;
 
+import java.io.File;
+
+import jackpal.androidterm.compat.TypefaceCompat;
 import jackpal.androidterm.emulatorview.ColorScheme;
 import jackpal.androidterm.emulatorview.EmulatorView;
 import jackpal.androidterm.emulatorview.TermSession;
@@ -31,11 +35,23 @@ public class TermView extends EmulatorView {
         super(context, session, metrics);
     }
 
+    protected Typeface loadTypeface(String spath) {
+        Typeface result=Typeface.MONOSPACE;
+        if(!spath.isEmpty()) {
+            File path=new File(spath);
+            if(path.exists()) {
+                result=TypefaceCompat.createFromFile(path);
+            }
+        }
+        return result;
+    }
+
     public void updatePrefs(TermSettings settings, ColorScheme scheme) {
         if (scheme == null) {
             scheme = new ColorScheme(settings.getColorScheme());
         }
 
+        setmTypeface(loadTypeface(settings.getFontPath()));
         setTextSize(settings.getFontSize());
         setUseCookedIME(settings.useCookedIME());
         setColorScheme(scheme);

--- a/term/src/main/java/jackpal/androidterm/TermView.java
+++ b/term/src/main/java/jackpal/androidterm/TermView.java
@@ -37,8 +37,10 @@ public class TermView extends EmulatorView {
 
     protected Typeface loadTypeface(String spath) {
         Typeface result=Typeface.MONOSPACE;
-        if(!spath.isEmpty()) {
-            File path=new File(spath);
+
+        if(spath!="") {
+            //File path=new File(spath);
+            File path=getContext().getFileStreamPath(spath);
             if(path.exists()) {
                 result=TypefaceCompat.createFromFile(path);
             }

--- a/term/src/main/java/jackpal/androidterm/compat/TypefaceCompat.java
+++ b/term/src/main/java/jackpal/androidterm/compat/TypefaceCompat.java
@@ -14,18 +14,22 @@ import jackpal.androidterm.emulatorview.compat.*;
 public class TypefaceCompat {
     private static class Api4OrLater {
         @TargetApi(4)
-        public static Typeface createFromFile(File path) {
+        public static Typeface createFromFile(File path,Typeface defaultValue) {
             Typeface result=Typeface.createFromFile(path);
             if(result.equals(Typeface.DEFAULT)) {
-                result=Typeface.MONOSPACE;
+                result=defaultValue;
             }
             return result;
         }
     }
     public static Typeface createFromFile(File path) {
+        return createFromFile(path,Typeface.MONOSPACE);
+    }
+
+    public static Typeface createFromFile(File path, Typeface defaulValue) {
         if(jackpal.androidterm.emulatorview.compat.AndroidCompat.SDK < 4 ) {
-            return Typeface.MONOSPACE;
+            return defaulValue;
         }
-        return Api4OrLater.createFromFile(path);
+        return Api4OrLater.createFromFile(path,defaulValue);
     }
 }

--- a/term/src/main/java/jackpal/androidterm/compat/TypefaceCompat.java
+++ b/term/src/main/java/jackpal/androidterm/compat/TypefaceCompat.java
@@ -1,9 +1,11 @@
-package jackpal.androidterm.emulatorview.compat;
+package jackpal.androidterm.compat;
 
 import android.annotation.TargetApi;
 import android.graphics.Typeface;
 
 import java.io.File;
+
+import jackpal.androidterm.emulatorview.compat.*;
 
 /**
  * Typeface creation shim
@@ -13,11 +15,15 @@ public class TypefaceCompat {
     private static class Api4OrLater {
         @TargetApi(4)
         public static Typeface createFromFile(File path) {
-            return Typeface.createFromFile(path);
+            Typeface result=Typeface.createFromFile(path);
+            if(result.equals(Typeface.DEFAULT)) {
+                result=Typeface.MONOSPACE;
+            }
+            return result;
         }
     }
     public static Typeface createFromFile(File path) {
-        if(AndroidCompat.SDK < 4 ) {
+        if(jackpal.androidterm.emulatorview.compat.AndroidCompat.SDK < 4 ) {
             return Typeface.MONOSPACE;
         }
         return Api4OrLater.createFromFile(path);

--- a/term/src/main/java/jackpal/androidterm/util/TermSettings.java
+++ b/term/src/main/java/jackpal/androidterm/util/TermSettings.java
@@ -50,6 +50,7 @@ public class TermSettings {
     private boolean mDoPathExtensions;
     private boolean mAllowPathPrepend;
     private String mHomePath;
+    private String mFontPath;
 
     private String mPrependPath = null;
     private String mAppendPath = null;
@@ -81,6 +82,7 @@ public class TermSettings {
     private static final String ALT_SENDS_ESC = "alt_sends_esc";
     private static final String MOUSE_TRACKING = "mouse_tracking";
     private static final String USE_KEYBOARD_SHORTCUTS = "use_keyboard_shortcuts";
+    private static final String CUSTOM_FONT_PATH = "custom_font_filepath";
 
     public static final int WHITE               = 0xffffffff;
     public static final int BLACK               = 0xff000000;
@@ -182,6 +184,7 @@ public class TermSettings {
         mAltSendsEsc = res.getBoolean(R.bool.pref_alt_sends_esc_default);
         mMouseTracking = res.getBoolean(R.bool.pref_mouse_tracking_default);
         mUseKeyboardShortcuts = res.getBoolean(R.bool.pref_use_keyboard_shortcuts_default);
+        mFontPath = res.getString(R.string.pref_customfontfilepath_default);
     }
 
     public void readPrefs(SharedPreferences prefs) {
@@ -212,6 +215,7 @@ public class TermSettings {
         mMouseTracking = readBooleanPref(MOUSE_TRACKING, mMouseTracking);
         mUseKeyboardShortcuts = readBooleanPref(USE_KEYBOARD_SHORTCUTS,
                 mUseKeyboardShortcuts);
+        mFontPath = readStringPref(CUSTOM_FONT_PATH,"");
         mPrefs = null;  // we leak a Context if we hold on to this
     }
 
@@ -370,4 +374,6 @@ public class TermSettings {
     public String getHomePath() {
         return mHomePath;
     }
+
+    public String getFontPath() { return mFontPath;}
 }

--- a/term/src/main/res/values/defaults.xml
+++ b/term/src/main/res/values/defaults.xml
@@ -4,6 +4,7 @@
    <string name="pref_statusbar_default" translatable="false">1</string>
    <integer name="pref_actionbar_default">1</integer>
    <integer name="pref_orientation_default">0</integer>
+   <string name="pref_customfontfilepath_default"></string>
    <string name="pref_cursorstyle_default" translatable="false">0</string>
    <string name="pref_cursorblink_default" translatable="false">0</string>
    <string name="pref_fontsize_default" translatable="false">10</string>

--- a/term/src/main/res/values/strings.xml
+++ b/term/src/main/res/values/strings.xml
@@ -165,8 +165,11 @@
 
   <string name="title_custom_font_filepath">Custom font file</string>
   <string name="custom_font_filepath_summary">Touch to pick a font file</string>
+
   <string name="custom_font_filepath_summary_reset"> ( Touch to set it to system default )</string>
-  <string name="custom_font_filepath_summary_error">Could not use the file picker result to get the file path</string>
+  <string name="custom_font_filepath_summary_error_filepicker">Could not use the file</string>
+  <string name="custom_font_filepath_summary_error_filepicker_Intent">Could not find a usable Filepicker</string>
+
 
   <string name="help">Help</string>
   <string name="help_url" translatable="false">http://jackpal.github.com/Android-Terminal-Emulator/help/index.html</string>

--- a/term/src/main/res/values/strings.xml
+++ b/term/src/main/res/values/strings.xml
@@ -163,6 +163,11 @@
   <string name="use_keyboard_shortcuts_summary_on">Ctrl-Tab: cycle window, Ctrl-Shift-N: new window, Ctrl-Shift-V: paste.</string>
   <string name="use_keyboard_shortcuts_summary_off">Keyboard shortcuts disabled.</string>
 
+  <string name="title_custom_font_filepath">Custom font file</string>
+  <string name="custom_font_filepath_summary">Touch to pick a font file</string>
+  <string name="custom_font_filepath_summary_reset"> ( Touch to set it to system default )</string>
+  <string name="custom_font_filepath_summary_error">Could not use the file picker result to get the file path</string>
+
   <string name="help">Help</string>
   <string name="help_url" translatable="false">http://jackpal.github.com/Android-Terminal-Emulator/help/index.html</string>
   <string name="activity_term_here_title">Term here</string>

--- a/term/src/main/res/xml/preferences.xml
+++ b/term/src/main/res/xml/preferences.xml
@@ -91,6 +91,13 @@
                 android:entryValues="@array/entryvalues_color_preference"
                 android:dialogTitle="@string/dialog_title_color_preference" />
 
+        <EditTextPreference
+            android:key="custom_font_filepath"
+            android:defaultValue=""
+            android:title="Custom font file path"
+            android:summary="Enter the path to the custom font file you wish to use ( Please use a monospaced font )"
+            android:dialogTitle="Custom font file path"/>
+
         <CheckBoxPreference
                 android:key="utf8_by_default"
                 android:defaultValue="@bool/pref_utf8_by_default_default"

--- a/term/src/main/res/xml/preferences.xml
+++ b/term/src/main/res/xml/preferences.xml
@@ -71,7 +71,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-            android:title="@string/text_preferences">
+            android:title="@string/text_preferences" android:key="text_category">
 
         <ListPreference
                 android:key="fontsize"
@@ -95,8 +95,8 @@
         <Preference
             android:key="custom_font_filepath"
             android:defaultValue=""
-            android:title="Custom font file"
-            android:summary="Touch to pick a font file"
+            android:title="@string/title_custom_font_filepath"
+            android:summary="@string/custom_font_filepath_summary"
             >
 
         </Preference>

--- a/term/src/main/res/xml/preferences.xml
+++ b/term/src/main/res/xml/preferences.xml
@@ -91,12 +91,15 @@
                 android:entryValues="@array/entryvalues_color_preference"
                 android:dialogTitle="@string/dialog_title_color_preference" />
 
-        <EditTextPreference
+
+        <Preference
             android:key="custom_font_filepath"
             android:defaultValue=""
-            android:title="Custom font file path"
-            android:summary="Enter the path to the custom font file you wish to use ( Please use a monospaced font )"
-            android:dialogTitle="Custom font file path"/>
+            android:title="Custom font file"
+            android:summary="Touch to pick a font file"
+            >
+
+        </Preference>
 
         <CheckBoxPreference
                 android:key="utf8_by_default"


### PR DESCRIPTION
Allows for the user to set a custom font with a fallback to MONOSPACE as a default

feature request #290

Currently the path input is a little bit non-user-friendly as it requires to type the path of the font in the preferences text field. But it is better than writing the font path to an arbitrary config file.

The cursor positioning, of course, go very wrong when using a non-monospaced font. 

Currently looking to improve it by using a file picking intent if possible, but the feature is usable enough, and, in my opinion, would be greatly appreciated by the users for day to day task with the terminal emulator.