### PR TITLE
Use ClipData.Item.coerceToText() to be able to paste data from any source

### DIFF
--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV11.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV11.java
@@ -1,16 +1,18 @@
 package jackpal.androidterm.emulatorview.compat;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.ClipData;
 import android.content.ClipDescription;
 import android.content.Context;
 import android.content.ClipboardManager;
 
-@SuppressLint("NewApi")
+@TargetApi(11)
 public class ClipboardManagerCompatV11 implements ClipboardManagerCompat {
     private final ClipboardManager clip;
-
+    private Context context;
     public ClipboardManagerCompatV11(Context context) {
+        this.context=context;
         clip = (ClipboardManager) context.getApplicationContext()
                 .getSystemService(Context.CLIPBOARD_SERVICE);
     }
@@ -18,13 +20,14 @@ public class ClipboardManagerCompatV11 implements ClipboardManagerCompat {
     @Override
     public CharSequence getText() {
         ClipData.Item item = clip.getPrimaryClip().getItemAt(0);
-        return item.getText();
+        if(item.getText()!=null)
+            return item.getText();
+        return item.coerceToText(context);
     }
 
     @Override
     public boolean hasText() {
-        return (clip.hasPrimaryClip() && clip.getPrimaryClipDescription()
-                .hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN));
+        return clip.hasPrimaryClip();
     }
 
     @Override

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV11.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/compat/ClipboardManagerCompatV11.java
@@ -1,9 +1,7 @@
 package jackpal.androidterm.emulatorview.compat;
 
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.ClipData;
-import android.content.ClipDescription;
 import android.content.Context;
 import android.content.ClipboardManager;
 


### PR DESCRIPTION
Use the coerseToText function for getting text data to accept text from most source as described [here](http://developer.android.com/guide/topics/text/copy-paste.html#CoerceToText), which allow for pasting data copied from rich text source ( source as browser html ) as requested in issue #378.